### PR TITLE
feat: expand basic example to optionally create new resource group

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ TBC
 <!-- BEGIN EXAMPLES HOOK -->
 ## Examples
 
-- [ Basic PowerVS Infrastructure Module Example](examples/basic)
-- [ Catalog PowerVS Infrastructure Module Example](examples/standard-catalog)
+- [# Catalog PowerVS Infrastructure Module Example](examples/standard-catalog)
+- [# Basic PowerVS Infrastructure Module Example](examples/basic)
 <!-- END EXAMPLES HOOK -->
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -26,7 +26,9 @@ Use of this resource for production deployments is not recommended. Instead, gen
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_existing_resource_group"></a> [existing\_resource\_group](#module\_existing\_resource\_group) | git::https://github.com/terraform-ibm-modules/terraform-ibm-resource-group.git | v1.0.0 |
 | <a name="module_pvs"></a> [pvs](#module\_pvs) | ../../ | n/a |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | git::https://github.com/terraform-ibm-modules/terraform-ibm-resource-group.git | v1.0.0 |
 
 ## Resources
 
@@ -43,6 +45,7 @@ Use of this resource for production deployments is not recommended. Instead, gen
 | <a name="input_cloud_connection_gr"></a> [cloud\_connection\_gr](#input\_cloud\_connection\_gr) | Enable global routing for this cloud connection. Can be specified when creating new connection | `bool` | `true` | no |
 | <a name="input_cloud_connection_metered"></a> [cloud\_connection\_metered](#input\_cloud\_connection\_metered) | Enable metered for this cloud connection. Can be specified when creating new connection | `bool` | `false` | no |
 | <a name="input_cloud_connection_speed"></a> [cloud\_connection\_speed](#input\_cloud\_connection\_speed) | Speed in megabits per sec. Supported values are 50, 100, 200, 500, 1000, 2000, 5000, 10000. Required when creating new connection | `string` | `"5000"` | no |
+| <a name="input_existing_resource_group_name"></a> [existing\_resource\_group\_name](#input\_existing\_resource\_group\_name) | Existing resource group name to use for this example. If null, a new resource group will be created. | `string` | `null` | no |
 | <a name="input_ibmcloud_api_key"></a> [ibmcloud\_api\_key](#input\_ibmcloud\_api\_key) | IBM Cloud Api Key | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix for resources which will be created. | `string` | `"pvs"` | no |
 | <a name="input_pvs_backup_network"></a> [pvs\_backup\_network](#input\_pvs\_backup\_network) | IBM Cloud PowerVS Backup Network name and cidr which will be created. | `map(any)` | <pre>{<br>  "cidr": "10.52.0.0/24",<br>  "name": "bkp_net"<br>}</pre> | no |
@@ -50,7 +53,6 @@ Use of this resource for production deployments is not recommended. Instead, gen
 | <a name="input_pvs_service_name"></a> [pvs\_service\_name](#input\_pvs\_service\_name) | Name of IBM Cloud PowerVS service which will be created | `string` | `"power-service"` | no |
 | <a name="input_pvs_sshkey_name"></a> [pvs\_sshkey\_name](#input\_pvs\_sshkey\_name) | Name of IBM Cloud PowerVS SSH Key which will be created | `string` | `"ssh-key-pvs"` | no |
 | <a name="input_pvs_zone"></a> [pvs\_zone](#input\_pvs\_zone) | IBM Cloud PowerVS Zone. Valid values: sao01,osa21,tor01,us-south,dal12,us-east,tok04,lon04,lon06,eu-de-1,eu-de-2,syd04,syd05 | `string` | `"syd04"` | no |
-| <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | An existing resource group name to use for this example | `string` | `null` | no |
 | <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Optional list of tags to be added to created resources | `list(string)` | `[]` | no |
 | <a name="input_reuse_cloud_connections"></a> [reuse\_cloud\_connections](#input\_reuse\_cloud\_connections) | When the value is true, cloud connections will be reused (and is already attached to Transit gateway) | `bool` | `true` | no |
 | <a name="input_transit_gateway_name"></a> [transit\_gateway\_name](#input\_transit\_gateway\_name) | Name of the existing transit gateway. Existing name must be provided when you want to create new cloud connections. | `string` | `null` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -64,7 +64,37 @@ resource "ibm_is_ssh_key" "ssh_key" {
   public_key = trimspace(tls_private_key.tls_key.public_key_openssh)
 }
 
+########################################################################################################################
+# Account Resource Group
+########################################################################################################################
+
+locals {
+  resource_group_name = var.existing_resource_group_name == null ? module.resource_group[0].resource_group_name : module.existing_resource_group[0].resource_group_name
+}
+
+module "existing_resource_group" {
+  count                        = var.existing_resource_group_name == null ? 0 : 1
+  source                       = "git::https://github.com/terraform-ibm-modules/terraform-ibm-resource-group.git?ref=v1.0.0"
+  existing_resource_group_name = var.existing_resource_group_name
+}
+
+module "resource_group" {
+  count               = var.existing_resource_group_name == null ? 1 : 0
+  source              = "git::https://github.com/terraform-ibm-modules/terraform-ibm-resource-group.git?ref=v1.0.0"
+  resource_group_name = "${var.prefix}-rg"
+}
+
+########################################################################################################################
+# Instantiate PowerVS infrastructure
+########################################################################################################################
+
+
 module "pvs" {
+  # Explicit dependency needed here - likely due to different provider alias used in this example
+  depends_on = [
+    local.resource_group_name
+  ]
+
   providers = {
     ibm = ibm.ibm-pvs
   }
@@ -72,7 +102,7 @@ module "pvs" {
   source = "../../"
 
   pvs_zone                 = var.pvs_zone
-  pvs_resource_group_name  = var.resource_group
+  pvs_resource_group_name  = local.resource_group_name
   pvs_service_name         = "${var.prefix}-${var.pvs_service_name}"
   tags                     = var.resource_tags
   pvs_sshkey_name          = "${var.prefix}-${var.pvs_sshkey_name}"

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -4,9 +4,9 @@ variable "pvs_zone" {
   default     = "syd04"
 }
 
-variable "resource_group" {
+variable "existing_resource_group_name" {
   type        = string
-  description = "An existing resource group name to use for this example"
+  description = "Existing resource group name to use for this example. If null, a new resource group will be created."
   default     = null
 }
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -3,9 +3,10 @@ package test
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/random"
 	"strings"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
@@ -18,8 +19,8 @@ const defaultExampleTerraformDir = "examples/basic"
 var prefix = fmt.Sprintf("pvs-%s", strings.ToLower(random.UniqueId()))
 
 var terraformVars = map[string]interface{}{
-	"resource_group": resourceGroup,
-	"prefix":         prefix,
+	"existing_resource_group_name": resourceGroup,
+	"prefix":                       prefix,
 }
 
 func TestRunDefaultExample(t *testing.T) {


### PR DESCRIPTION
### Description

Expand basic example to optionally create new resource group.

This essentially fixes the limitation noted at https://github.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/pull/5#issuecomment-1209622435


**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
