### PR TITLE
fix for subscription issue with x86 servers

### DIFF
--- a/submodules/power_management_services_setup/scripts/squid_proxy.sh
+++ b/submodules/power_management_services_setup/scripts/squid_proxy.sh
@@ -104,8 +104,22 @@ if [ "$OS_DETECTED" == "SLES" ]; then
      if [ "$OS_Activated" -ge 1 ] ; then
         echo "OS is Registered"
      else
-      ##### check if the system is a HANA or Netweaver VM, should be a ppc64le VM
         ARCH=$(uname -p)
+      ##### check if the system is a x86_64 processor VM
+        if [[ "$ARCH" == "x86_64" ]]; then
+      #### Wait for registration to complete
+ 	     count=0
+             while [[ $count -le 15 ]]; do
+                sleep 60
+                OS_Activated="$(SUSEConnect --status | grep  -ci "\"status\":\"Registered\"")"
+                if  [[ "$OS_Activated" -ge 1 ]] ; then
+        	   echo "OS is Registered"
+    		   break;
+	        fi
+	        count=$(( count +1 ))
+	     done
+        fi
+      ##### check if the system is a HANA or Netweaver VM, should be a ppc64le VM
      	if [[ "$ARCH" == "ppc64le" ]]; then
 		    SUSEConnect --de-register
             SUSEConnect --cleanup
@@ -125,19 +139,16 @@ if [ "$OS_DETECTED" == "SLES" ]; then
                 fi
 		        sleep 60
             done
-	    if [[ $count -gt 15 ]]; then
+	 fi
+	 if [[ $count -gt 15 ]]; then
 	        echo "Timeout: SLES registration process failed, or still ongoing"
 	        exit 1
-	    fi
-            Activation_status="$(SUSEConnect --status | grep -ci "error")"
-            if [ "$Activation_status" != 0 ] ; then
-               	echo "OS activation Failed"
+	 fi
+         Activation_status="$(SUSEConnect --status | grep -ci "error")"
+         if [ "$Activation_status" != 0 ] ; then
+              	echo "OS activation Failed"
                	exit 1
-            fi
-        else
-            echo "System is not registered. Please register the system first and rerun the script"
-            exit 1
-        fi
+         fi
       fi
     fi
     if [[ $no_proxy_ip =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$ ]] ; then


### PR DESCRIPTION
Signed-off-by: sahityajain123 <sahityajain@in.ibm.com>

### Description

squid_proxy.sh script has been changed, to include a sleep for validating, if SUSE subscription has been completed. As the check was not there, commands requiring SUSE subscription to be enabled were failing. Now we sleep for 60s , 15 times ( total 15 minutes ) for SUSE registration to complete. 
 
**Check the relevant boxes:**
- [X ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
