### PR TITLE
docs: use templating to auto set version, etc. within usage

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -8,7 +8,7 @@
                     "label": "PowerVS workspace",
                     "name": "standard",
                     "working_directory": "examples/ibm-catalog/standard-solution",
-                    "usage_template": "module \"power-infrastructure\" {\n  source =                     \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//${{workingDirectory}}?archive=tgz&catalogID=${{catalogID}}&flavor=${{flavor}}&kind=${{kind}}&name=${{name}}&version=${{version}}\"\n  prerequisite_workspace_id   = var.prerequisite_workspace_id\n  powervs_zone                = var.powervs_zone\n  powervs_resource_group_name = var.powervs_resource_group_name\n  ssh_private_key             = var.ssh_private_key\n  ibmcloud_api_key            = var.ibmcloud_api_key\n}",
+                    "usage_template": "module \"power-infrastructure\" {\n  source =                     \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//${{workingDirectory}}?archive=tgz&flavor=${{flavor}}&kind=${{kind}}&name=${{name}}&version=${{version}}\"\n  prerequisite_workspace_id   = var.prerequisite_workspace_id\n  powervs_zone                = var.powervs_zone\n  powervs_resource_group_name = var.powervs_resource_group_name\n  ssh_private_key             = var.ssh_private_key\n  ibmcloud_api_key            = var.ibmcloud_api_key\n}",
                     "compliance": {
                         "controls": [
                             {

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -8,7 +8,7 @@
                     "label": "PowerVS workspace",
                     "name": "standard",
                     "working_directory": "examples/ibm-catalog/standard-solution",
-                    "usage": "module \"power-infrastructure\" {\n  source = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//examples/ibm-catalog/standard-solution?archive=tgz&kind=terraform&name=terraform-ibm-powervs-catalog-powervs-sap-infrastructure&version=2.0.9\"\n  prerequisite_workspace_id   = var.prerequisite_workspace_id\n  powervs_zone                = var.powervs_zone\n  powervs_resource_group_name = var.powervs_resource_group_name\n  ssh_private_key             = var.ssh_private_key\n  ibmcloud_api_key            = var.ibmcloud_api_key\n}",
+                    "usage_template": "module \"power-infrastructure\" {\n  source =                     \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//${{workingDirectory}}?archive=tgz&catalogID=${{catalogID}}&flavor=${{flavor}}&kind=${{kind}}&name=${{name}}&version=${{version}}\"\n  prerequisite_workspace_id   = var.prerequisite_workspace_id\n  powervs_zone                = var.powervs_zone\n  powervs_resource_group_name = var.powervs_resource_group_name\n  ssh_private_key             = var.ssh_private_key\n  ibmcloud_api_key            = var.ibmcloud_api_key\n}",
                     "compliance": {
                         "controls": [
                             {


### PR DESCRIPTION
### Description

Update ibm_catalog.json file to use the template functionality for the `usage` string.  The template is the property `usage_template` which is the same as the previous `usage` except that it contains placeholders for version, offering name, etc.   The usage_template causes the generation of the usage string with the appropriate substitution.

