### PR TITLE
fix: updated the landing zone to 4.10.0, updated presets

### DIFF
--- a/presets/slz-for-powervs/rhel-vpc-pvs-quickstart.preset.json.tfpl
+++ b/presets/slz-for-powervs/rhel-vpc-pvs-quickstart.preset.json.tfpl
@@ -11,6 +11,7 @@
   },
   "clusters": [],
   "enable_transit_gateway": true,
+  "transit_gateway_global": true,
   "transit_gateway_connections": [
     "edge"
   ],
@@ -133,6 +134,7 @@
         "zone-3": []
       },
       "default_security_group_rules": [],
+      "clean_default_sg_acl": true,
       "flow_logs_bucket_name": null,
       "network_acls": [
         {
@@ -903,7 +905,7 @@
   "vsi": [
     {
       "boot_volume_encryption_key_name": "slz-vsi-volume-key",
-      "image_name": "ibm-redhat-8-4-amd64-sap-applications-4",
+      "image_name": "ibm-redhat-8-6-amd64-sap-applications-4",
       "machine_type": "cx2-2x4",
       "name": "inet-svs",
       "resource_group": "slz-edge-rg",

--- a/presets/slz-for-powervs/rhel-vpc-pvs.preset.json.tftpl
+++ b/presets/slz-for-powervs/rhel-vpc-pvs.preset.json.tftpl
@@ -1151,7 +1151,7 @@
     },
     {
       "boot_volume_encryption_key_name": "slz-vsi-volume-key",
-      "image_name": "ibm-redhat-8-4-amd64-sap-applications-4",
+      "image_name": "ibm-redhat-8-6-amd64-sap-applications-4",
       "machine_type": "cx2-2x4",
       "name": "private-svs",
       "resource_group": "slz-workload-rg",
@@ -1205,7 +1205,7 @@
     },
     {
       "boot_volume_encryption_key_name": "slz-vsi-volume-key",
-      "image_name": "ibm-redhat-8-4-amd64-sap-applications-4",
+      "image_name": "ibm-redhat-8-6-amd64-sap-applications-4",
       "machine_type": "cx2-2x4",
       "name": "inet-svs",
       "resource_group": "slz-edge-rg",

--- a/presets/slz-for-powervs/rhel-vpc-pvs.preset.json.tftpl
+++ b/presets/slz-for-powervs/rhel-vpc-pvs.preset.json.tftpl
@@ -11,6 +11,7 @@
   },
   "clusters": [],
   "enable_transit_gateway": true,
+  "transit_gateway_global": true,
   "transit_gateway_connections": [
     "management",
     "workload",
@@ -165,6 +166,7 @@
         "zone-3": []
       },
       "default_security_group_rules": [],
+      "clean_default_sg_acl": true,
       "flow_logs_bucket_name": null,
       "network_acls": [
         {
@@ -828,6 +830,7 @@
         "zone-3": []
       },
       "default_security_group_rules": [],
+      "clean_default_sg_acl": true,
       "flow_logs_bucket_name": null,
       "network_acls": [
         {
@@ -933,6 +936,7 @@
         "zone-3": []
       },
       "default_security_group_rules": [],
+      "clean_default_sg_acl": true,
       "flow_logs_bucket_name": null,
       "network_acls": [
         {
@@ -1101,7 +1105,7 @@
   "vsi": [
     {
       "boot_volume_encryption_key_name": "slz-vsi-volume-key",
-      "image_name": "ibm-redhat-8-4-amd64-sap-applications-4",
+      "image_name": "ibm-redhat-8-6-amd64-sap-applications-4",
       "machine_type": "cx2-2x4",
       "name": "jump-box",
       "resource_group": "slz-management-rg",

--- a/presets/slz-for-powervs/sles-vpc-pvs.preset.json.tftpl
+++ b/presets/slz-for-powervs/sles-vpc-pvs.preset.json.tftpl
@@ -1151,7 +1151,7 @@
     },
     {
       "boot_volume_encryption_key_name": "slz-vsi-volume-key",
-      "image_name": "ibm-sles-15-3-amd64-sap-applications-3",
+      "image_name": "ibm-sles-15-4-amd64-sap-applications-6",
       "machine_type": "cx2-2x4",
       "name": "private-svs",
       "resource_group": "slz-workload-rg",
@@ -1205,7 +1205,7 @@
     },
     {
       "boot_volume_encryption_key_name": "slz-vsi-volume-key",
-      "image_name": "ibm-sles-15-3-amd64-sap-applications-3",
+      "image_name": "ibm-sles-15-4-amd64-sap-applications-6",
       "machine_type": "cx2-2x4",
       "name": "inet-svs",
       "resource_group": "slz-edge-rg",

--- a/presets/slz-for-powervs/sles-vpc-pvs.preset.json.tftpl
+++ b/presets/slz-for-powervs/sles-vpc-pvs.preset.json.tftpl
@@ -11,6 +11,7 @@
   },
   "clusters": [],
   "enable_transit_gateway": true,
+  "transit_gateway_global": true,
   "transit_gateway_connections": [
     "management",
     "workload",
@@ -165,6 +166,7 @@
         "zone-3": []
       },
       "default_security_group_rules": [],
+      "clean_default_sg_acl": true,
       "flow_logs_bucket_name": null,
       "network_acls": [
         {
@@ -828,6 +830,7 @@
         "zone-3": []
       },
       "default_security_group_rules": [],
+      "clean_default_sg_acl": true,
       "flow_logs_bucket_name": null,
       "network_acls": [
         {
@@ -933,6 +936,7 @@
         "zone-3": []
       },
       "default_security_group_rules": [],
+      "clean_default_sg_acl": true,
       "flow_logs_bucket_name": null,
       "network_acls": [
         {
@@ -1101,7 +1105,7 @@
   "vsi": [
     {
       "boot_volume_encryption_key_name": "slz-vsi-volume-key",
-      "image_name": "ibm-sles-15-3-amd64-sap-applications-3",
+      "image_name": "ibm-sles-15-4-amd64-sap-applications-6",
       "machine_type": "cx2-2x4",
       "name": "jump-box",
       "resource_group": "slz-management-rg",

--- a/solutions/full-stack/README.md
+++ b/solutions/full-stack/README.md
@@ -42,7 +42,7 @@ Catalog image names to be imported into infrastructure can be found [here](./doc
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.4.6 |
+| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.10.0 |
 | <a name="module_powervs_infra"></a> [powervs\_infra](#module\_powervs\_infra) | ../../ | n/a |
 
 ### Resources

--- a/solutions/full-stack/main.tf
+++ b/solutions/full-stack/main.tf
@@ -67,7 +67,6 @@ module "landing_zone" {
   version   = "4.10.0"
   providers = { ibm = ibm.ibm-is }
 
-  #  ibmcloud_api_key     = var.ibmcloud_api_key
   ssh_public_key       = var.ssh_public_key
   region               = lookup(local.ibm_powervs_zone_cloud_region_map, var.powervs_zone, null)
   prefix               = var.prefix

--- a/solutions/full-stack/main.tf
+++ b/solutions/full-stack/main.tf
@@ -64,10 +64,10 @@ locals {
 
 module "landing_zone" {
   source    = "terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module"
-  version   = "4.4.6"
+  version   = "4.10.0"
   providers = { ibm = ibm.ibm-is }
 
-  ibmcloud_api_key     = var.ibmcloud_api_key
+  #  ibmcloud_api_key     = var.ibmcloud_api_key
   ssh_public_key       = var.ssh_public_key
   region               = lookup(local.ibm_powervs_zone_cloud_region_map, var.powervs_zone, null)
   prefix               = var.prefix

--- a/solutions/quickstart/README.md
+++ b/solutions/quickstart/README.md
@@ -43,7 +43,7 @@ This example sets up the following infrastructure:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_demo_pi_instance"></a> [demo\_pi\_instance](#module\_demo\_pi\_instance) | git::https://github.com/terraform-ibm-modules/terraform-ibm-powervs-instance.git | v0.3.0 |
-| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.4.6 |
+| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.10.0 |
 | <a name="module_powervs_infra"></a> [powervs\_infra](#module\_powervs\_infra) | ../../ | n/a |
 
 ### Resources

--- a/solutions/quickstart/main.tf
+++ b/solutions/quickstart/main.tf
@@ -82,7 +82,6 @@ module "landing_zone" {
   version   = "4.10.0"
   providers = { ibm = ibm.ibm-is }
 
-  #  ibmcloud_api_key     = var.ibmcloud_api_key
   ssh_public_key       = var.ssh_public_key
   region               = lookup(local.ibm_powervs_zone_cloud_region_map, var.powervs_zone, null)
   prefix               = var.prefix

--- a/solutions/quickstart/main.tf
+++ b/solutions/quickstart/main.tf
@@ -79,10 +79,10 @@ locals {
 
 module "landing_zone" {
   source    = "terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module"
-  version   = "4.4.6"
+  version   = "4.10.0"
   providers = { ibm = ibm.ibm-is }
 
-  ibmcloud_api_key     = var.ibmcloud_api_key
+  #  ibmcloud_api_key     = var.ibmcloud_api_key
   ssh_public_key       = var.ssh_public_key
   region               = lookup(local.ibm_powervs_zone_cloud_region_map, var.powervs_zone, null)
   prefix               = var.prefix


### PR DESCRIPTION
### Description

- Enabled the global routing for transit gateway in the presets, 
- updated RHEL and SLES images for VPC VSI in the presets,
- upgraded the landing zone version to 4.10.0 for the full-stack and quickstart solutions,
- added a new parameter clean_default_sg_acl into the presets 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
