### PR TITLE
fix: remove depends on for powervs_infra module for fullstack solution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
   call-terraform-ci-pipeline:
-    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-terraform-module-ci-v2.yml@v1.17.9
+    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-terraform-module-ci-v2.yml@v1.18.0
     secrets: inherit
     with:
       craSCCv2: true
       craConfigYamlFile: "cra-config.yaml"
+      tfswitchDir: "solutions/full-stack"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   call-terraform-release-pipeline:
-    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-release.yml@v1.17.9
+    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-release.yml@v1.18.0
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ module "power-infrastructure" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <1.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.49.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ module "power-infrastructure" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <=1.5.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <1.6 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.49.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ module "power-infrastructure" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <=1.5.5 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.49.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ module "power-infrastructure" {
 | <a name="input_ssh_private_key"></a> [ssh\_private\_key](#input\_ssh\_private\_key) | Private SSH key (RSA format) used to login to IBM PowerVS instances. Should match to uploaded public SSH key referenced by 'ssh\_public\_key'. Entered data must be in heredoc strings format (https://www.terraform.io/language/expressions/strings#heredoc-strings). The key is not uploaded or stored. | `string` | n/a | yes |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | Public SSH Key for the PowerVM to create. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | List of tag names for the IBM Cloud PowerVS Workspace. | `list(string)` | `null` | no |
-| <a name="input_transit_gateway_name"></a> [transit\_gateway\_name](#input\_transit\_gateway\_name) | Name of the existing transit gateway. Required when you create new IBM Cloud connections. Set it to null if reusing cloud connections | `string` | n/a | yes |
+| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | ID of the existing transit gateway. Required when you create new IBM Cloud connections. Set it to null if reusing cloud connections | `string` | n/a | yes |
 
 ### Outputs
 

--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -8,6 +8,6 @@ CRA_TARGETS:
       TF_VAR_powervs_zone: "syd05"
       TF_VAR_powervs_resource_group_name: "Default"
       TF_VAR_landing_zone_configuration: "rhel"
-      TF_VAR_external_access_ip: "0.0.0.0/32"
+      TF_VAR_external_access_ip: "0.0.0.0/0"
       TF_VAR_ssh_public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDb8qoH4U47+79ssT6FdsOIxxZY8/oxWc66WPwqHfpjCgDRP3Rc1uq2YEKIRJba2DzNFnf+byinH0O9hwjKZ/3l7HxNtvQZXdCnT79TOT/wGbcHBV8ZUTBkUOx67ryS0F5bKDdMDWdsWkMXkRb8AAsJWLAeuFsfMYQjMBLmvrMsRRB6GG+97jF18ghqHjuBTX1FNF9fcytEaz7WfP8KrgSYRcQOauIVlMJyOmh3gZl84u14SXwQKhQrdvqt47ZErKH+fbsgxfOvvmYgr5RktKjbmi+lyBkxRM7//BaKcPw5saThf1MiEesJxIqyL16DW9LXdWei74xHNuF65K03y975Qr9CtPkr1rGgxwU2ksqLy1NN5TnF4erd1VSuLZ5BLov7JRJ2K17ttt0agp9VmkjRFIivOek= some-user@testing-box"
       TF_VAR_ssh_private_key: "some_key"

--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -6,7 +6,7 @@ CRA_TARGETS:
     CRA_ENVIRONMENT_VARIABLES:
       TF_VAR_prefix: "cra-infra"
       TF_VAR_powervs_zone: "syd05"
-      TF_VAR_powervs_resource_group_name: "Automation"
+      TF_VAR_powervs_resource_group_name: "Default"
       TF_VAR_landing_zone_configuration: "rhel"
       TF_VAR_external_access_ip: "0.0.0.0/32"
       TF_VAR_ssh_public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDb8qoH4U47+79ssT6FdsOIxxZY8/oxWc66WPwqHfpjCgDRP3Rc1uq2YEKIRJba2DzNFnf+byinH0O9hwjKZ/3l7HxNtvQZXdCnT79TOT/wGbcHBV8ZUTBkUOx67ryS0F5bKDdMDWdsWkMXkRb8AAsJWLAeuFsfMYQjMBLmvrMsRRB6GG+97jF18ghqHjuBTX1FNF9fcytEaz7WfP8KrgSYRcQOauIVlMJyOmh3gZl84u14SXwQKhQrdvqt47ZErKH+fbsgxfOvvmYgr5RktKjbmi+lyBkxRM7//BaKcPw5saThf1MiEesJxIqyL16DW9LXdWei74xHNuF65K03y975Qr9CtPkr1rGgxwU2ksqLy1NN5TnF4erd1VSuLZ5BLov7JRJ2K17ttt0agp9VmkjRFIivOek= some-user@testing-box"

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -216,7 +216,6 @@
         "name": "mgmt_net"
       },
       "source": [
-        "module.powervs_cloud_connection_attach",
         "module.powervs_workspace"
       ],
       "pos": {
@@ -230,8 +229,6 @@
       "description": "Existing IBM Cloud resource group name.",
       "required": true,
       "source": [
-        "module.powervs_cloud_connection_attach.data.ibm_resource_group.resource_group_ds.name",
-        "module.powervs_cloud_connection_create.data.ibm_resource_group.resource_group_ds.name",
         "module.powervs_workspace.data.ibm_resource_group.resource_group_ds.name"
       ],
       "pos": {
@@ -265,8 +262,6 @@
       "default": "power-workspace",
       "required": true,
       "source": [
-        "module.powervs_cloud_connection_attach.data.ibm_resource_instance.powervs_workspace_ds.name",
-        "module.powervs_cloud_connection_create.data.ibm_resource_instance.powervs_workspace_ds.name",
         "module.powervs_cloud_connection_create.ibm_tg_connection.ibm_powervs_workspace_attach_per.name",
         "module.powervs_workspace.ibm_resource_instance.powervs_workspace.name"
       ],
@@ -284,8 +279,7 @@
       "description": "IBM Cloud PowerVS zone.",
       "required": true,
       "source": [
-        "module.powervs_cloud_connection_attach.data.ibm_resource_instance.powervs_workspace_ds.location",
-        "module.powervs_cloud_connection_create.data.ibm_resource_instance.powervs_workspace_ds.location",
+        "module.powervs_cloud_connection_create",
         "module.powervs_workspace.ibm_resource_instance.powervs_workspace.location"
       ],
       "pos": {
@@ -293,8 +287,7 @@
         "line": 1
       },
       "cloud_data_type": "region",
-      "immutable": true,
-      "computed": true
+      "immutable": true
     },
     "reuse_cloud_connections": {
       "name": "reuse_cloud_connections",
@@ -380,18 +373,21 @@
         "type": "TypeString"
       }
     },
-    "transit_gateway_name": {
-      "name": "transit_gateway_name",
+    "transit_gateway_id": {
+      "name": "transit_gateway_id",
       "type": "string",
-      "description": "Name of the existing transit gateway. Required when you create new IBM Cloud connections. Set it to null if reusing cloud connections",
+      "description": "ID of the existing transit gateway. Required when you create new IBM Cloud connections. Set it to null if reusing cloud connections",
       "required": true,
       "source": [
-        "module.powervs_cloud_connection_create.data.ibm_tg_gateway.tg_gateway_ds.name"
+        "module.powervs_cloud_connection_create.ibm_tg_connection.ibm_powervs_workspace_attach_per.gateway",
+        "module.powervs_cloud_connection_create.ibm_tg_connection.ibm_tg_connection_1.gateway",
+        "module.powervs_cloud_connection_create.ibm_tg_connection.ibm_tg_connection_2.gateway"
       ],
       "pos": {
         "filename": "variables.tf",
         "line": 62
-      }
+      },
+      "immutable": true
     }
   },
   "outputs": {
@@ -483,7 +479,7 @@
     },
     "powervs_workspace_crn": {
       "name": "powervs_workspace_crn",
-      "description": "PowerVS infrastructure workspace CRN.",
+      "description": "PowerVS infrastructure workspace CRN. The full deployment CRN as defined in the global catalog. The Cloud Resource Name (CRN) of the deployment location where the instance is provisioned.",
       "value": "module.powervs_workspace.powervs_workspace_crn",
       "pos": {
         "filename": "outputs.tf",
@@ -551,7 +547,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 77
+        "line": 101
       }
     }
   },
@@ -636,7 +632,7 @@
       "data_resources": {},
       "pos": {
         "filename": "main.tf",
-        "line": 84
+        "line": 108
       }
     },
     "configure_nfs": {
@@ -718,7 +714,7 @@
       "data_resources": {},
       "pos": {
         "filename": "main.tf",
-        "line": 110
+        "line": 134
       }
     },
     "configure_ntp": {
@@ -800,7 +796,7 @@
       "data_resources": {},
       "pos": {
         "filename": "main.tf",
-        "line": 97
+        "line": 121
       }
     },
     "configure_squid": {
@@ -882,7 +878,7 @@
       "data_resources": {},
       "pos": {
         "filename": "main.tf",
-        "line": 65
+        "line": 89
       }
     },
     "initial_validation": {
@@ -895,18 +891,14 @@
       "data_resources": {},
       "pos": {
         "filename": "main.tf",
-        "line": 10
+        "line": 15
       }
     },
     "powervs_cloud_connection_attach": {
       "name": "powervs_cloud_connection_attach",
       "source": "./submodules/powervs_cloudconnection_attach",
       "attributes": {
-        "cloud_connection_count": "cloud_connection_count",
-        "powervs_resource_group_name": "powervs_resource_group_name",
-        "powervs_subnet_names": "powervs_management_network",
-        "powervs_workspace_name": "powervs_workspace_name",
-        "powervs_zone": "powervs_zone"
+        "cloud_connection_count": "cloud_connection_count"
       },
       "managed_resources": {
         "ibm_pi_cloud_connection_network_attach.powervs_subnet_bkp_nw_attach": {
@@ -914,14 +906,16 @@
           "type": "ibm_pi_cloud_connection_network_attach",
           "name": "powervs_subnet_bkp_nw_attach",
           "attributes": {
-            "count": "cloud_connection_count"
+            "count": "cloud_connection_count",
+            "pi_cloud_instance_id": "powervs_workspace_guid",
+            "pi_network_id": "powervs_subnet_ids"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_attach/main.tf",
-            "line": 47
+            "line": 23
           }
         },
         "ibm_pi_cloud_connection_network_attach.powervs_subnet_bkp_nw_attach_backup": {
@@ -929,14 +923,16 @@
           "type": "ibm_pi_cloud_connection_network_attach",
           "name": "powervs_subnet_bkp_nw_attach_backup",
           "attributes": {
-            "count": "cloud_connection_count"
+            "count": "cloud_connection_count",
+            "pi_cloud_instance_id": "powervs_workspace_guid",
+            "pi_network_id": "powervs_subnet_ids"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_attach/main.tf",
-            "line": 63
+            "line": 45
           }
         },
         "ibm_pi_cloud_connection_network_attach.powervs_subnet_mgmt_nw_attach": {
@@ -944,14 +940,16 @@
           "type": "ibm_pi_cloud_connection_network_attach",
           "name": "powervs_subnet_mgmt_nw_attach",
           "attributes": {
-            "count": "cloud_connection_count"
+            "count": "cloud_connection_count",
+            "pi_cloud_instance_id": "powervs_workspace_guid",
+            "pi_network_id": "powervs_subnet_ids"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_attach/main.tf",
-            "line": 39
+            "line": 13
           }
         },
         "ibm_pi_cloud_connection_network_attach.powervs_subnet_mgmt_nw_attach_backup": {
@@ -959,14 +957,16 @@
           "type": "ibm_pi_cloud_connection_network_attach",
           "name": "powervs_subnet_mgmt_nw_attach_backup",
           "attributes": {
-            "count": "cloud_connection_count"
+            "count": "cloud_connection_count",
+            "pi_cloud_instance_id": "powervs_workspace_guid",
+            "pi_network_id": "powervs_subnet_ids"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_attach/main.tf",
-            "line": 55
+            "line": 34
           }
         }
       },
@@ -975,36 +975,8 @@
           "mode": "data",
           "type": "ibm_pi_cloud_connections",
           "name": "cloud_connection_ds",
-          "provider": {
-            "name": "ibm"
-          },
-          "pos": {
-            "filename": "submodules/powervs_cloudconnection_attach/main.tf",
-            "line": 31
-          }
-        },
-        "data.ibm_pi_network.powervs_subnets_ds": {
-          "mode": "data",
-          "type": "ibm_pi_network",
-          "name": "powervs_subnets_ds",
           "attributes": {
-            "count": "powervs_subnet_names",
-            "pi_network_name": "powervs_subnet_names"
-          },
-          "provider": {
-            "name": "ibm"
-          },
-          "pos": {
-            "filename": "submodules/powervs_cloudconnection_attach/main.tf",
-            "line": 21
-          }
-        },
-        "data.ibm_resource_group.resource_group_ds": {
-          "mode": "data",
-          "type": "ibm_resource_group",
-          "name": "resource_group_ds",
-          "attributes": {
-            "name": "powervs_resource_group_name"
+            "pi_cloud_instance_id": "powervs_workspace_guid"
           },
           "provider": {
             "name": "ibm"
@@ -1013,27 +985,11 @@
             "filename": "submodules/powervs_cloudconnection_attach/main.tf",
             "line": 5
           }
-        },
-        "data.ibm_resource_instance.powervs_workspace_ds": {
-          "mode": "data",
-          "type": "ibm_resource_instance",
-          "name": "powervs_workspace_ds",
-          "attributes": {
-            "location": "powervs_zone",
-            "name": "powervs_workspace_name"
-          },
-          "provider": {
-            "name": "ibm"
-          },
-          "pos": {
-            "filename": "submodules/powervs_cloudconnection_attach/main.tf",
-            "line": 9
-          }
         }
       },
       "pos": {
         "filename": "main.tf",
-        "line": 49
+        "line": 74
       }
     },
     "powervs_cloud_connection_create": {
@@ -1046,10 +1002,9 @@
         "cloud_connection_name_prefix": "cloud_connection_name_prefix",
         "cloud_connection_speed": "cloud_connection_speed",
         "count": "reuse_cloud_connections",
-        "powervs_resource_group_name": "powervs_resource_group_name",
         "powervs_workspace_name": "powervs_workspace_name",
         "powervs_zone": "powervs_zone",
-        "transit_gateway_name": "transit_gateway_name"
+        "transit_gateway_id": "transit_gateway_id"
       },
       "managed_resources": {
         "ibm_pi_cloud_connection.cloud_connection": {
@@ -1060,14 +1015,15 @@
             "count": "cloud_connection_count",
             "pi_cloud_connection_global_routing": "cloud_connection_gr",
             "pi_cloud_connection_metered": "cloud_connection_metered",
-            "pi_cloud_connection_speed": "cloud_connection_speed"
+            "pi_cloud_connection_speed": "cloud_connection_speed",
+            "pi_cloud_instance_id": "powervs_workspace_guid"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 26
+            "line": 14
           }
         },
         "ibm_pi_cloud_connection.cloud_connection_backup": {
@@ -1078,14 +1034,15 @@
             "count": "cloud_connection_count",
             "pi_cloud_connection_global_routing": "cloud_connection_gr",
             "pi_cloud_connection_metered": "cloud_connection_metered",
-            "pi_cloud_connection_speed": "cloud_connection_speed"
+            "pi_cloud_connection_speed": "cloud_connection_speed",
+            "pi_cloud_instance_id": "powervs_workspace_guid"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 37
+            "line": 25
           }
         },
         "ibm_tg_connection.ibm_powervs_workspace_attach_per": {
@@ -1094,14 +1051,16 @@
           "name": "ibm_powervs_workspace_attach_per",
           "attributes": {
             "count": "per_enabled",
-            "name": "powervs_workspace_name"
+            "gateway": "transit_gateway_id",
+            "name": "powervs_workspace_name",
+            "network_id": "powervs_workspace_id"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 123
+            "line": 103
           }
         },
         "ibm_tg_connection.ibm_tg_connection_1": {
@@ -1109,14 +1068,15 @@
           "type": "ibm_tg_connection",
           "name": "ibm_tg_connection_1",
           "attributes": {
-            "count": "cloud_connection_count"
+            "count": "cloud_connection_count",
+            "gateway": "transit_gateway_id"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 99
+            "line": 79
           }
         },
         "ibm_tg_connection.ibm_tg_connection_2": {
@@ -1124,14 +1084,15 @@
           "type": "ibm_tg_connection",
           "name": "ibm_tg_connection_2",
           "attributes": {
-            "count": "cloud_connection_count"
+            "count": "cloud_connection_count",
+            "gateway": "transit_gateway_id"
           },
           "provider": {
             "name": "ibm"
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 109
+            "line": 89
           }
         },
         "time_sleep.dl_1_resource_propagation": {
@@ -1146,7 +1107,7 @@
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 75
+            "line": 55
           }
         },
         "time_sleep.dl_2_resource_propagation": {
@@ -1161,7 +1122,7 @@
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 85
+            "line": 65
           }
         }
       },
@@ -1178,7 +1139,7 @@
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 61
+            "line": 41
           }
         },
         "data.ibm_dl_gateway.gateway_ds_2": {
@@ -1193,59 +1154,13 @@
           },
           "pos": {
             "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 68
-          }
-        },
-        "data.ibm_resource_group.resource_group_ds": {
-          "mode": "data",
-          "type": "ibm_resource_group",
-          "name": "resource_group_ds",
-          "attributes": {
-            "name": "powervs_resource_group_name"
-          },
-          "provider": {
-            "name": "ibm"
-          },
-          "pos": {
-            "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 11
-          }
-        },
-        "data.ibm_resource_instance.powervs_workspace_ds": {
-          "mode": "data",
-          "type": "ibm_resource_instance",
-          "name": "powervs_workspace_ds",
-          "attributes": {
-            "location": "powervs_zone",
-            "name": "powervs_workspace_name"
-          },
-          "provider": {
-            "name": "ibm"
-          },
-          "pos": {
-            "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 15
-          }
-        },
-        "data.ibm_tg_gateway.tg_gateway_ds": {
-          "mode": "data",
-          "type": "ibm_tg_gateway",
-          "name": "tg_gateway_ds",
-          "attributes": {
-            "name": "transit_gateway_name"
-          },
-          "provider": {
-            "name": "ibm"
-          },
-          "pos": {
-            "filename": "submodules/powervs_cloudconnection_create/main.tf",
-            "line": 53
+            "line": 48
           }
         }
       },
       "pos": {
         "filename": "main.tf",
-        "line": 32
+        "line": 50
       }
     },
     "powervs_workspace": {
@@ -1272,7 +1187,7 @@
           },
           "pos": {
             "filename": "submodules/powervs_workspace/main.tf",
-            "line": 86
+            "line": 92
           }
         },
         "ibm_pi_image.import_images_2": {
@@ -1284,7 +1199,7 @@
           },
           "pos": {
             "filename": "submodules/powervs_workspace/main.tf",
-            "line": 98
+            "line": 104
           }
         },
         "ibm_pi_image.import_images_3": {
@@ -1296,7 +1211,7 @@
           },
           "pos": {
             "filename": "submodules/powervs_workspace/main.tf",
-            "line": 110
+            "line": 116
           }
         },
         "ibm_pi_key.ssh_key": {
@@ -1395,20 +1310,69 @@
         }
       },
       "outputs": {
+        "powervs_workspace_backup_subnet_id": {
+          "name": "powervs_workspace_backup_subnet_id",
+          "description": "PowerVS infrastructure workspace backup subnet id. The unique identifier of the network.",
+          "value": "ibm_pi_network.backup_network.network_id",
+          "pos": {
+            "filename": "submodules/powervs_workspace/outputs.tf",
+            "line": 26
+          },
+          "type": "TypeString"
+        },
         "powervs_workspace_crn": {
           "name": "powervs_workspace_crn",
-          "description": "PowerVS infrastructure workspace CRN.",
+          "description": "PowerVS infrastructure workspace CRN. The full deployment CRN as defined in the global catalog. The Cloud Resource Name (CRN) of the deployment location where the instance is provisioned.",
           "value": "ibm_resource_instance.powervs_workspace.target_crn",
           "pos": {
             "filename": "submodules/powervs_workspace/outputs.tf",
             "line": 1
           },
           "type": "TypeString"
+        },
+        "powervs_workspace_guid": {
+          "name": "powervs_workspace_guid",
+          "description": "PowerVS infrastructure workspace guid. The GUID of the resource instance.",
+          "value": "ibm_resource_instance.powervs_workspace.guid",
+          "pos": {
+            "filename": "submodules/powervs_workspace/outputs.tf",
+            "line": 11
+          },
+          "type": "TypeString"
+        },
+        "powervs_workspace_id": {
+          "name": "powervs_workspace_id",
+          "description": "PowerVS infrastructure workspace id. The unique identifier of the new resource instance.",
+          "value": "ibm_resource_instance.powervs_workspace.id",
+          "pos": {
+            "filename": "submodules/powervs_workspace/outputs.tf",
+            "line": 16
+          }
+        },
+        "powervs_workspace_management_subnet_id": {
+          "name": "powervs_workspace_management_subnet_id",
+          "description": "PowerVS infrastructure workspace management subnet id. The unique identifier of the network.",
+          "value": "ibm_pi_network.management_network.network_id",
+          "pos": {
+            "filename": "submodules/powervs_workspace/outputs.tf",
+            "line": 21
+          },
+          "type": "TypeString"
+        },
+        "powervs_workspace_resource_id": {
+          "name": "powervs_workspace_resource_id",
+          "description": "PowerVS infrastructure workspace resource id. The unique ID of the offering. This value is provided by and stored in the global catalog.",
+          "value": "ibm_resource_instance.powervs_workspace.resource_id",
+          "pos": {
+            "filename": "submodules/powervs_workspace/outputs.tf",
+            "line": 6
+          },
+          "type": "TypeString"
         }
       },
       "pos": {
         "filename": "main.tf",
-        "line": 18
+        "line": 29
       }
     }
   }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -518,7 +518,7 @@
     }
   },
   "required_core": [
-    "\u003e= 1.3, \u003c=1.5.5"
+    "\u003e= 1.3, \u003c1.6"
   ],
   "required_providers": {
     "ibm": {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -518,7 +518,7 @@
     }
   },
   "required_core": [
-    "\u003e= 1.3"
+    "\u003e= 1.3, \u003c=1.5.5"
   ],
   "required_providers": {
     "ibm": {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -518,7 +518,7 @@
     }
   },
   "required_core": [
-    "\u003e= 1.3, \u003c1.6"
+    "\u003e= 1.3"
   ],
   "required_providers": {
     "ibm": {

--- a/presets/slz-for-powervs/rhel-vpc-pvs-quickstart.preset.json.tfpl
+++ b/presets/slz-for-powervs/rhel-vpc-pvs-quickstart.preset.json.tfpl
@@ -1027,7 +1027,8 @@
           "name": "data",
           "profile": "5iops-tier",
           "capacity": 500,
-          "encryption_key": "slz-vsi-volume-key"
+          "encryption_key": "slz-vsi-volume-key",
+          "resource_group_id" : "65xxxxxxxxxxxxxxxa3fd"
         }
       ]
     }

--- a/presets/slz-for-powervs/rhel-vpc-pvs.preset.json.tftpl
+++ b/presets/slz-for-powervs/rhel-vpc-pvs.preset.json.tftpl
@@ -1303,7 +1303,8 @@
           "name": "data",
           "profile": "5iops-tier",
           "capacity": 1000,
-          "encryption_key": "slz-vsi-volume-key"
+          "encryption_key": "slz-vsi-volume-key",
+          "resource_group_id" : "65xxxxxxxxxxxxxxxa3fd"
         }
       ]
     },

--- a/presets/slz-for-powervs/sles-vpc-pvs.preset.json.tftpl
+++ b/presets/slz-for-powervs/sles-vpc-pvs.preset.json.tftpl
@@ -1303,7 +1303,8 @@
           "name": "data",
           "profile": "5iops-tier",
           "capacity": 1000,
-          "encryption_key": "slz-vsi-volume-key"
+          "encryption_key": "slz-vsi-volume-key",
+          "resource_group_id" : "65xxxxxxxxxxxxxxxa3fd"
         }
       ]
     },

--- a/solutions/extension/README.md
+++ b/solutions/extension/README.md
@@ -36,7 +36,7 @@ Catalog image names to be imported into infrastructure can be found [here](../fu
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.7 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/extension/README.md
+++ b/solutions/extension/README.md
@@ -36,7 +36,7 @@ Catalog image names to be imported into infrastructure can be found [here](../fu
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <=1.5.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/extension/README.md
+++ b/solutions/extension/README.md
@@ -37,7 +37,7 @@ Catalog image names to be imported into infrastructure can be found [here](../fu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.58.1 |
 
 ### Modules
 
@@ -49,8 +49,8 @@ Catalog image names to be imported into infrastructure can be found [here](../fu
 
 | Name | Type |
 |------|------|
-| [ibm_schematics_output.schematics_output](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.56.1/docs/data-sources/schematics_output) | data source |
-| [ibm_schematics_workspace.schematics_workspace](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.56.1/docs/data-sources/schematics_workspace) | data source |
+| [ibm_schematics_output.schematics_output](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.58.1/docs/data-sources/schematics_output) | data source |
+| [ibm_schematics_workspace.schematics_workspace](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.58.1/docs/data-sources/schematics_workspace) | data source |
 
 ### Inputs
 

--- a/solutions/extension/README.md
+++ b/solutions/extension/README.md
@@ -88,6 +88,7 @@ Catalog image names to be imported into infrastructure can be found [here](../fu
 | <a name="output_prefix"></a> [prefix](#output\_prefix) | The prefix that is associated with all resources |
 | <a name="output_proxy_host_or_ip_port"></a> [proxy\_host\_or\_ip\_port](#output\_proxy\_host\_or\_ip\_port) | Proxy host:port for created PowerVS infrastructure. |
 | <a name="output_schematics_workspace_id"></a> [schematics\_workspace\_id](#output\_schematics\_workspace\_id) | ID of the IBM Cloud Schematics workspace. Returns null if not ran in Schematics |
+| <a name="output_transit_gateway_id"></a> [transit\_gateway\_id](#output\_transit\_gateway\_id) | The ID of transit gateway. |
 | <a name="output_transit_gateway_name"></a> [transit\_gateway\_name](#output\_transit\_gateway\_name) | The name of the transit gateway. |
 | <a name="output_vpc_names"></a> [vpc\_names](#output\_vpc\_names) | A list of the names of the VPC. |
 | <a name="output_vsi_list"></a> [vsi\_list](#output\_vsi\_list) | A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP. |

--- a/solutions/extension/README.md
+++ b/solutions/extension/README.md
@@ -36,7 +36,7 @@ Catalog image names to be imported into infrastructure can be found [here](../fu
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <=1.5.5 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/extension/main.tf
+++ b/solutions/extension/main.tf
@@ -46,6 +46,7 @@ locals {
   prefix               = local.fullstack_output[0].prefix.value
   ssh_public_key       = local.fullstack_output[0].ssh_public_key.value
   transit_gateway_name = local.fullstack_output[0].transit_gateway_name.value
+  transit_gateway_id   = local.fullstack_output[0].transit_gateway_id.value
 
   access_host_or_ip_exists   = contains(keys(local.fullstack_output[0]), "access_host_or_ip") ? true : false
   access_host_or_ip          = local.access_host_or_ip_exists ? local.fullstack_output[0].access_host_or_ip.value : ""
@@ -122,7 +123,7 @@ module "powervs_infra" {
   ssh_private_key             = null
   powervs_management_network  = var.powervs_management_network
   powervs_backup_network      = var.powervs_backup_network
-  transit_gateway_name        = local.transit_gateway_name
+  transit_gateway_id          = local.transit_gateway_id
   reuse_cloud_connections     = false
   cloud_connection_count      = var.cloud_connection["count"]
   cloud_connection_speed      = var.cloud_connection["speed"]

--- a/solutions/extension/outputs.tf
+++ b/solutions/extension/outputs.tf
@@ -18,6 +18,11 @@ output "transit_gateway_name" {
   value       = local.transit_gateway_name
 }
 
+output "transit_gateway_id" {
+  description = "The ID of transit gateway."
+  value       = local.transit_gateway_id
+}
+
 output "vsi_list" {
   description = "A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP."
   value       = local.fullstack_output[0].vsi_list.value

--- a/solutions/extension/versions.tf
+++ b/solutions/extension/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, < 1.6"
+  required_version = ">= 1.3, < 1.7"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/extension/versions.tf
+++ b/solutions/extension/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.56.1"
+      version = "=1.58.1"
     }
   }
 }

--- a/solutions/extension/versions.tf
+++ b/solutions/extension/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, < 1.7"
+  required_version = ">= 1.3, <=1.5.5"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/extension/versions.tf
+++ b/solutions/extension/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, <=1.5.5"
+  required_version = ">= 1.3, < 1.6"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/full-stack/README.md
+++ b/solutions/full-stack/README.md
@@ -35,7 +35,7 @@ Catalog image names to be imported into infrastructure can be found [here](./doc
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3,  <=1.5.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <=1.5.5 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/full-stack/README.md
+++ b/solutions/full-stack/README.md
@@ -94,6 +94,7 @@ No resources.
 | <a name="output_proxy_host_or_ip_port"></a> [proxy\_host\_or\_ip\_port](#output\_proxy\_host\_or\_ip\_port) | Proxy host:port for created PowerVS infrastructure. |
 | <a name="output_schematics_workspace_id"></a> [schematics\_workspace\_id](#output\_schematics\_workspace\_id) | ID of the IBM Cloud Schematics workspace. Returns null if not ran in Schematics. |
 | <a name="output_ssh_public_key"></a> [ssh\_public\_key](#output\_ssh\_public\_key) | The string value of the ssh public key used when deploying VPC |
+| <a name="output_transit_gateway_id"></a> [transit\_gateway\_id](#output\_transit\_gateway\_id) | The ID of transit gateway. |
 | <a name="output_transit_gateway_name"></a> [transit\_gateway\_name](#output\_transit\_gateway\_name) | The name of the transit gateway. |
 | <a name="output_vpc_names"></a> [vpc\_names](#output\_vpc\_names) | A list of the names of the VPC. |
 | <a name="output_vsi_list"></a> [vsi\_list](#output\_vsi\_list) | A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP. |

--- a/solutions/full-stack/README.md
+++ b/solutions/full-stack/README.md
@@ -35,7 +35,7 @@ Catalog image names to be imported into infrastructure can be found [here](./doc
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3,  <=1.5.5 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/full-stack/README.md
+++ b/solutions/full-stack/README.md
@@ -35,7 +35,7 @@ Catalog image names to be imported into infrastructure can be found [here](./doc
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <=1.5.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/full-stack/README.md
+++ b/solutions/full-stack/README.md
@@ -36,13 +36,13 @@ Catalog image names to be imported into infrastructure can be found [here](./doc
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.58.1 |
 
 ### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.10.0 |
+| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.13.0 |
 | <a name="module_powervs_infra"></a> [powervs\_infra](#module\_powervs\_infra) | ../../ | n/a |
 
 ### Resources

--- a/solutions/full-stack/README.md
+++ b/solutions/full-stack/README.md
@@ -35,7 +35,7 @@ Catalog image names to be imported into infrastructure can be found [here](./doc
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.7 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/full-stack/main.tf
+++ b/solutions/full-stack/main.tf
@@ -78,8 +78,6 @@ locals {
   nfs_disk_exists     = [for vsi in local.landing_zone_config.vsi : vsi.block_storage_volumes[0].capacity if contains(keys(vsi), "block_storage_volumes")]
   nfs_disk_size       = length(local.nfs_disk_exists) >= 1 ? local.nfs_disk_exists[0] : ""
 
-  transit_gateway_name = module.landing_zone.transit_gateway_name
-
   fip_vsi_exists           = contains(keys(module.landing_zone), "fip_vsi") ? true : false
   access_host_or_ip_exists = local.fip_vsi_exists ? contains(keys(module.landing_zone.fip_vsi[0]), "floating_ip") ? true : false : false
   access_host_or_ip        = local.access_host_or_ip_exists ? module.landing_zone.fip_vsi[0].floating_ip : ""
@@ -138,10 +136,8 @@ locals {
 # PowerVS Infrastructure module
 #####################################################
 
-
 module "powervs_infra" {
-  source     = "../../"
-  depends_on = [module.landing_zone]
+  source = "../../"
 
   powervs_zone                = var.powervs_zone
   powervs_resource_group_name = var.powervs_resource_group_name
@@ -153,7 +149,7 @@ module "powervs_infra" {
   ssh_private_key             = var.ssh_private_key
   powervs_management_network  = var.powervs_management_network
   powervs_backup_network      = var.powervs_backup_network
-  transit_gateway_name        = local.transit_gateway_name
+  transit_gateway_id          = module.landing_zone.transit_gateway_data.id
   reuse_cloud_connections     = false
   cloud_connection_count      = var.cloud_connection["count"]
   cloud_connection_speed      = var.cloud_connection["speed"]

--- a/solutions/full-stack/main.tf
+++ b/solutions/full-stack/main.tf
@@ -64,7 +64,7 @@ locals {
 
 module "landing_zone" {
   source    = "terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module"
-  version   = "4.10.0"
+  version   = "4.13.0"
   providers = { ibm = ibm.ibm-is }
 
   ssh_public_key       = var.ssh_public_key

--- a/solutions/full-stack/outputs.tf
+++ b/solutions/full-stack/outputs.tf
@@ -23,6 +23,11 @@ output "transit_gateway_name" {
   value       = module.landing_zone.transit_gateway_name
 }
 
+output "transit_gateway_id" {
+  description = "The ID of transit gateway."
+  value       = module.landing_zone.transit_gateway_data.id
+}
+
 output "vsi_list" {
   description = "A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP."
   value       = module.landing_zone.vsi_list

--- a/solutions/full-stack/versions.tf
+++ b/solutions/full-stack/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, < 1.6"
+  required_version = ">= 1.3, < 1.7"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/full-stack/versions.tf
+++ b/solutions/full-stack/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.56.1"
+      version = "=1.58.1"
     }
   }
 }

--- a/solutions/full-stack/versions.tf
+++ b/solutions/full-stack/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3,  <=1.5.5"
+  required_version = ">= 1.3, <=1.5.5"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/full-stack/versions.tf
+++ b/solutions/full-stack/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, <=1.5.5"
+  required_version = ">= 1.3, < 1.6"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/full-stack/versions.tf
+++ b/solutions/full-stack/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, < 1.7"
+  required_version = ">= 1.3,  <=1.5.5"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/quickstart/README.md
+++ b/solutions/quickstart/README.md
@@ -35,7 +35,7 @@ This example sets up the following infrastructure:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3,  <=1.5.5 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/quickstart/README.md
+++ b/solutions/quickstart/README.md
@@ -36,14 +36,14 @@ This example sets up the following infrastructure:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.58.1 |
 
 ### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_demo_pi_instance"></a> [demo\_pi\_instance](#module\_demo\_pi\_instance) | git::https://github.com/terraform-ibm-modules/terraform-ibm-powervs-instance.git | v0.3.0 |
-| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.10.0 |
+| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.13.0 |
 | <a name="module_powervs_infra"></a> [powervs\_infra](#module\_powervs\_infra) | ../../ | n/a |
 
 ### Resources

--- a/solutions/quickstart/README.md
+++ b/solutions/quickstart/README.md
@@ -35,7 +35,7 @@ This example sets up the following infrastructure:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <=1.5.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/quickstart/README.md
+++ b/solutions/quickstart/README.md
@@ -35,7 +35,7 @@ This example sets up the following infrastructure:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.7 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/quickstart/README.md
+++ b/solutions/quickstart/README.md
@@ -100,6 +100,7 @@ No resources.
 | <a name="output_proxy_host_or_ip_port"></a> [proxy\_host\_or\_ip\_port](#output\_proxy\_host\_or\_ip\_port) | Proxy host:port for created PowerVS infrastructure. |
 | <a name="output_schematics_workspace_id"></a> [schematics\_workspace\_id](#output\_schematics\_workspace\_id) | ID of the IBM Cloud Schematics workspace. Returns null if not ran in Schematics. |
 | <a name="output_ssh_public_key"></a> [ssh\_public\_key](#output\_ssh\_public\_key) | The string value of the ssh public key used when deploying VPC |
+| <a name="output_transit_gateway_id"></a> [transit\_gateway\_id](#output\_transit\_gateway\_id) | The ID of transit gateway. |
 | <a name="output_transit_gateway_name"></a> [transit\_gateway\_name](#output\_transit\_gateway\_name) | The name of the transit gateway. |
 | <a name="output_vpc_names"></a> [vpc\_names](#output\_vpc\_names) | A list of the names of the VPC. |
 | <a name="output_vsi_list"></a> [vsi\_list](#output\_vsi\_list) | A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP. |

--- a/solutions/quickstart/README.md
+++ b/solutions/quickstart/README.md
@@ -35,7 +35,7 @@ This example sets up the following infrastructure:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3,  <=1.5.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, <=1.5.5 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.56.1 |
 
 ### Modules

--- a/solutions/quickstart/main.tf
+++ b/solutions/quickstart/main.tf
@@ -78,7 +78,7 @@ locals {
 
 module "landing_zone" {
   source    = "terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module"
-  version   = "4.10.0"
+  version   = "4.13.0"
   providers = { ibm = ibm.ibm-is }
 
   ssh_public_key       = var.ssh_public_key

--- a/solutions/quickstart/main.tf
+++ b/solutions/quickstart/main.tf
@@ -92,8 +92,6 @@ locals {
   nfs_disk_exists     = [for vsi in local.landing_zone_config.vsi : vsi.block_storage_volumes[0].capacity if contains(keys(vsi), "block_storage_volumes")]
   nfs_disk_size       = length(local.nfs_disk_exists) >= 1 ? local.nfs_disk_exists[0] : ""
 
-  transit_gateway_name = module.landing_zone.transit_gateway_name
-
   fip_vsi_exists           = contains(keys(module.landing_zone), "fip_vsi") ? true : false
   access_host_or_ip_exists = local.fip_vsi_exists ? contains(keys(module.landing_zone.fip_vsi[0]), "floating_ip") ? true : false : false
   access_host_or_ip        = local.access_host_or_ip_exists ? module.landing_zone.fip_vsi[0].floating_ip : ""
@@ -152,8 +150,7 @@ locals {
 }
 
 module "powervs_infra" {
-  source     = "../../"
-  depends_on = [module.landing_zone]
+  source = "../../"
 
   powervs_zone                = var.powervs_zone
   powervs_resource_group_name = var.powervs_resource_group_name
@@ -165,7 +162,7 @@ module "powervs_infra" {
   ssh_private_key             = var.ssh_private_key
   powervs_management_network  = var.powervs_management_network
   powervs_backup_network      = var.powervs_backup_network
-  transit_gateway_name        = local.transit_gateway_name
+  transit_gateway_id          = module.landing_zone.transit_gateway_data.id
   reuse_cloud_connections     = false
   cloud_connection_count      = var.cloud_connection["count"]
   cloud_connection_speed      = var.cloud_connection["speed"]

--- a/solutions/quickstart/main.tf
+++ b/solutions/quickstart/main.tf
@@ -209,7 +209,7 @@ locals {
 
 module "demo_pi_instance" {
   source     = "git::https://github.com/terraform-ibm-modules/terraform-ibm-powervs-instance.git?ref=v0.3.0"
-  depends_on = [module.landing_zone, module.powervs_infra]
+  depends_on = [module.powervs_infra]
 
   pi_zone                 = var.powervs_zone
   pi_resource_group_name  = var.powervs_resource_group_name

--- a/solutions/quickstart/outputs.tf
+++ b/solutions/quickstart/outputs.tf
@@ -23,6 +23,11 @@ output "transit_gateway_name" {
   value       = module.landing_zone.transit_gateway_name
 }
 
+output "transit_gateway_id" {
+  description = "The ID of transit gateway."
+  value       = module.landing_zone.transit_gateway_data.id
+}
+
 output "vsi_list" {
   description = "A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP."
   value       = module.landing_zone.vsi_list

--- a/solutions/quickstart/versions.tf
+++ b/solutions/quickstart/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, < 1.6"
+  required_version = ">= 1.3, < 1.7"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/quickstart/versions.tf
+++ b/solutions/quickstart/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.56.1"
+      version = "=1.58.1"
     }
   }
 }

--- a/solutions/quickstart/versions.tf
+++ b/solutions/quickstart/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3,  <=1.5.5"
+  required_version = ">= 1.3, <=1.5.5"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/quickstart/versions.tf
+++ b/solutions/quickstart/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, <=1.5.5"
+  required_version = ">= 1.3, < 1.6"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/solutions/quickstart/versions.tf
+++ b/solutions/quickstart/versions.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, < 1.7"
+  required_version = ">= 1.3,  <=1.5.5"
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/submodules/powervs_cloudconnection_attach/README.md
+++ b/submodules/powervs_cloudconnection_attach/README.md
@@ -41,19 +41,14 @@ No modules.
 | [ibm_pi_cloud_connection_network_attach.powervs_subnet_mgmt_nw_attach](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_cloud_connection_network_attach) | resource |
 | [ibm_pi_cloud_connection_network_attach.powervs_subnet_mgmt_nw_attach_backup](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_cloud_connection_network_attach) | resource |
 | [ibm_pi_cloud_connections.cloud_connection_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/pi_cloud_connections) | data source |
-| [ibm_pi_network.powervs_subnets_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/pi_network) | data source |
-| [ibm_resource_group.resource_group_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/resource_group) | data source |
-| [ibm_resource_instance.powervs_workspace_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/resource_instance) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloud_connection_count"></a> [cloud\_connection\_count](#input\_cloud\_connection\_count) | Number of cloud connections where private networks should be attached to. Default is to use redundant cloud connection pair. | `number` | n/a | yes |
-| <a name="input_powervs_resource_group_name"></a> [powervs\_resource\_group\_name](#input\_powervs\_resource\_group\_name) | Existing Resource Group Name | `string` | n/a | yes |
-| <a name="input_powervs_subnet_names"></a> [powervs\_subnet\_names](#input\_powervs\_subnet\_names) | List of IBM Cloud PowerVS subnet names to be attached to Cloud connection | `list(any)` | n/a | yes |
-| <a name="input_powervs_workspace_name"></a> [powervs\_workspace\_name](#input\_powervs\_workspace\_name) | Existing IBM Cloud PowerVS Workspace Name | `string` | n/a | yes |
-| <a name="input_powervs_zone"></a> [powervs\_zone](#input\_powervs\_zone) | IBM Cloud PowerVS Zone | `string` | n/a | yes |
+| <a name="input_powervs_subnet_ids"></a> [powervs\_subnet\_ids](#input\_powervs\_subnet\_ids) | List of IBM Cloud PowerVS subnet ids to be attached to Cloud connection. Maximum of 2 subnets in a list are supported. | `list(any)` | n/a | yes |
+| <a name="input_powervs_workspace_guid"></a> [powervs\_workspace\_guid](#input\_powervs\_workspace\_guid) | Existing IBM Cloud PowerVS Workspace GUID. | `string` | n/a | yes |
 
 ### Outputs
 

--- a/submodules/powervs_cloudconnection_attach/main.tf
+++ b/submodules/powervs_cloudconnection_attach/main.tf
@@ -1,69 +1,54 @@
-locals {
-  service_type = "power-iaas"
-}
-
-data "ibm_resource_group" "resource_group_ds" {
-  name = var.powervs_resource_group_name
-}
-
-data "ibm_resource_instance" "powervs_workspace_ds" {
-  name              = var.powervs_workspace_name
-  service           = local.service_type
-  location          = var.powervs_zone
-  resource_group_id = data.ibm_resource_group.resource_group_ds.id
-}
-
-
-#####################################################
-# Get IBM Cloud PowerVS subnet IDs
-#####################################################
-
-data "ibm_pi_network" "powervs_subnets_ds" {
-  count                = length(var.powervs_subnet_names)
-  pi_cloud_instance_id = data.ibm_resource_instance.powervs_workspace_ds.guid
-  pi_network_name      = var.powervs_subnet_names[count.index]
-}
-
-#####################################################
-# Reuse Cloud Connection to attach PVS subnets
-#####################################################
+#################################################
+# Attach PowerVS Subnets to CCs
+#################################################
 
 data "ibm_pi_cloud_connections" "cloud_connection_ds" {
-  pi_cloud_instance_id = data.ibm_resource_instance.powervs_workspace_ds.guid
+  pi_cloud_instance_id = var.powervs_workspace_guid
 }
 
-#########################################################################
-# Initialize landscape and attach management and backup private networks
-#########################################################################
+#################################################
+# Attach 2 subnets to both Cloud Connections
+#################################################
 
 resource "ibm_pi_cloud_connection_network_attach" "powervs_subnet_mgmt_nw_attach" {
-  depends_on             = [data.ibm_pi_network.powervs_subnets_ds[0]]
   count                  = var.cloud_connection_count > 0 ? 1 : 0
-  pi_cloud_instance_id   = data.ibm_resource_instance.powervs_workspace_ds.guid
+  pi_cloud_instance_id   = var.powervs_workspace_guid
   pi_cloud_connection_id = data.ibm_pi_cloud_connections.cloud_connection_ds.connections[0].cloud_connection_id
-  pi_network_id          = data.ibm_pi_network.powervs_subnets_ds[0].id
+  pi_network_id          = var.powervs_subnet_ids[0]
+  lifecycle {
+    ignore_changes = [pi_cloud_connection_id]
+  }
 }
 
 resource "ibm_pi_cloud_connection_network_attach" "powervs_subnet_bkp_nw_attach" {
-  depends_on             = [ibm_pi_cloud_connection_network_attach.powervs_subnet_mgmt_nw_attach, data.ibm_pi_network.powervs_subnets_ds[1]]
-  count                  = var.cloud_connection_count > 0 ? 1 : 0
-  pi_cloud_instance_id   = data.ibm_resource_instance.powervs_workspace_ds.guid
+  depends_on             = [ibm_pi_cloud_connection_network_attach.powervs_subnet_mgmt_nw_attach]
+  count                  = var.cloud_connection_count > 0 && length(var.powervs_subnet_ids) > 1 ? 1 : 0
+  pi_cloud_instance_id   = var.powervs_workspace_guid
   pi_cloud_connection_id = data.ibm_pi_cloud_connections.cloud_connection_ds.connections[0].cloud_connection_id
-  pi_network_id          = data.ibm_pi_network.powervs_subnets_ds[1].id
+  pi_network_id          = var.powervs_subnet_ids[1]
+  lifecycle {
+    ignore_changes = [pi_cloud_connection_id]
+  }
 }
 
 resource "ibm_pi_cloud_connection_network_attach" "powervs_subnet_mgmt_nw_attach_backup" {
   depends_on             = [ibm_pi_cloud_connection_network_attach.powervs_subnet_bkp_nw_attach]
   count                  = var.cloud_connection_count > 1 ? 1 : 0
-  pi_cloud_instance_id   = data.ibm_resource_instance.powervs_workspace_ds.guid
+  pi_cloud_instance_id   = var.powervs_workspace_guid
   pi_cloud_connection_id = data.ibm_pi_cloud_connections.cloud_connection_ds.connections[1].cloud_connection_id
-  pi_network_id          = data.ibm_pi_network.powervs_subnets_ds[0].id
+  pi_network_id          = var.powervs_subnet_ids[0]
+  lifecycle {
+    ignore_changes = [pi_cloud_connection_id]
+  }
 }
 
 resource "ibm_pi_cloud_connection_network_attach" "powervs_subnet_bkp_nw_attach_backup" {
-  count                  = var.cloud_connection_count > 1 ? 1 : 0
+  count                  = var.cloud_connection_count > 1 && length(var.powervs_subnet_ids) > 1 ? 1 : 0
   depends_on             = [ibm_pi_cloud_connection_network_attach.powervs_subnet_mgmt_nw_attach_backup]
-  pi_cloud_instance_id   = data.ibm_resource_instance.powervs_workspace_ds.guid
+  pi_cloud_instance_id   = var.powervs_workspace_guid
   pi_cloud_connection_id = data.ibm_pi_cloud_connections.cloud_connection_ds.connections[1].cloud_connection_id
-  pi_network_id          = data.ibm_pi_network.powervs_subnets_ds[1].id
+  pi_network_id          = var.powervs_subnet_ids[1]
+  lifecycle {
+    ignore_changes = [pi_cloud_connection_id]
+  }
 }

--- a/submodules/powervs_cloudconnection_attach/variables.tf
+++ b/submodules/powervs_cloudconnection_attach/variables.tf
@@ -1,21 +1,15 @@
-variable "powervs_zone" {
-  description = "IBM Cloud PowerVS Zone"
+variable "powervs_workspace_guid" {
+  description = "Existing IBM Cloud PowerVS Workspace GUID."
   type        = string
 }
 
-variable "powervs_resource_group_name" {
-  description = "Existing Resource Group Name"
-  type        = string
-}
-
-variable "powervs_workspace_name" {
-  description = "Existing IBM Cloud PowerVS Workspace Name"
-  type        = string
-}
-
-variable "powervs_subnet_names" {
-  description = "List of IBM Cloud PowerVS subnet names to be attached to Cloud connection"
+variable "powervs_subnet_ids" {
+  description = "List of IBM Cloud PowerVS subnet ids to be attached to Cloud connection. Maximum of 2 subnets in a list are supported."
   type        = list(any)
+  validation {
+    condition     = length(var.powervs_subnet_ids) > 2 ? false : true
+    error_message = "Maximum length of list can be 2 only. Supports only 2 subnet ids."
+  }
 }
 
 variable "cloud_connection_count" {

--- a/submodules/powervs_cloudconnection_create/README.md
+++ b/submodules/powervs_cloudconnection_create/README.md
@@ -49,9 +49,6 @@ No modules.
 | [time_sleep.dl_2_resource_propagation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [ibm_dl_gateway.gateway_ds_1](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/dl_gateway) | data source |
 | [ibm_dl_gateway.gateway_ds_2](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/dl_gateway) | data source |
-| [ibm_resource_group.resource_group_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/resource_group) | data source |
-| [ibm_resource_instance.powervs_workspace_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/resource_instance) | data source |
-| [ibm_tg_gateway.tg_gateway_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/tg_gateway) | data source |
 
 ### Inputs
 
@@ -63,10 +60,11 @@ No modules.
 | <a name="input_cloud_connection_name_prefix"></a> [cloud\_connection\_name\_prefix](#input\_cloud\_connection\_name\_prefix) | If null or empty string, default cloud connection name will be <zone>-conn-1. | `string` | `null` | no |
 | <a name="input_cloud_connection_speed"></a> [cloud\_connection\_speed](#input\_cloud\_connection\_speed) | Speed in megabits per sec. Supported values are 50, 100, 200, 500, 1000, 2000, 5000, 10000. Required when creating new connection. | `number` | n/a | yes |
 | <a name="input_per_enabled"></a> [per\_enabled](#input\_per\_enabled) | Set it to true if the DC is PER enabled, then cloud connections will not be created. | `bool` | n/a | yes |
-| <a name="input_powervs_resource_group_name"></a> [powervs\_resource\_group\_name](#input\_powervs\_resource\_group\_name) | Existing Resource Group Name. | `string` | n/a | yes |
+| <a name="input_powervs_workspace_guid"></a> [powervs\_workspace\_guid](#input\_powervs\_workspace\_guid) | Existing IBM Cloud PowerVS Workspace GUID. | `string` | n/a | yes |
+| <a name="input_powervs_workspace_id"></a> [powervs\_workspace\_id](#input\_powervs\_workspace\_id) | Existing IBM Cloud PowerVS Workspace ID. | `string` | n/a | yes |
 | <a name="input_powervs_workspace_name"></a> [powervs\_workspace\_name](#input\_powervs\_workspace\_name) | Existing IBM Cloud PowerVS Workspace Name. | `string` | n/a | yes |
 | <a name="input_powervs_zone"></a> [powervs\_zone](#input\_powervs\_zone) | IBM Cloud PowerVS Zone. | `string` | n/a | yes |
-| <a name="input_transit_gateway_name"></a> [transit\_gateway\_name](#input\_transit\_gateway\_name) | Name of the existing transit gateway. Required when creating new cloud connections. | `string` | n/a | yes |
+| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | Name of the existing transit gateway. Required when creating new cloud connections. | `string` | n/a | yes |
 
 ### Outputs
 

--- a/submodules/powervs_cloudconnection_create/variables.tf
+++ b/submodules/powervs_cloudconnection_create/variables.tf
@@ -3,17 +3,22 @@ variable "powervs_zone" {
   type        = string
 }
 
-variable "powervs_resource_group_name" {
-  description = "Existing Resource Group Name."
-  type        = string
-}
-
 variable "powervs_workspace_name" {
   description = "Existing IBM Cloud PowerVS Workspace Name."
   type        = string
 }
 
-variable "transit_gateway_name" {
+variable "powervs_workspace_guid" {
+  description = "Existing IBM Cloud PowerVS Workspace GUID."
+  type        = string
+}
+
+variable "powervs_workspace_id" {
+  description = "Existing IBM Cloud PowerVS Workspace ID."
+  type        = string
+}
+
+variable "transit_gateway_id" {
   description = "Name of the existing transit gateway. Required when creating new cloud connections."
   type        = string
 }

--- a/submodules/powervs_workspace/README.md
+++ b/submodules/powervs_workspace/README.md
@@ -68,5 +68,10 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_powervs_workspace_crn"></a> [powervs\_workspace\_crn](#output\_powervs\_workspace\_crn) | PowerVS infrastructure workspace CRN. |
+| <a name="output_powervs_workspace_backup_subnet_id"></a> [powervs\_workspace\_backup\_subnet\_id](#output\_powervs\_workspace\_backup\_subnet\_id) | PowerVS infrastructure workspace backup subnet id. The unique identifier of the network. |
+| <a name="output_powervs_workspace_crn"></a> [powervs\_workspace\_crn](#output\_powervs\_workspace\_crn) | PowerVS infrastructure workspace CRN. The full deployment CRN as defined in the global catalog. The Cloud Resource Name (CRN) of the deployment location where the instance is provisioned. |
+| <a name="output_powervs_workspace_guid"></a> [powervs\_workspace\_guid](#output\_powervs\_workspace\_guid) | PowerVS infrastructure workspace guid. The GUID of the resource instance. |
+| <a name="output_powervs_workspace_id"></a> [powervs\_workspace\_id](#output\_powervs\_workspace\_id) | PowerVS infrastructure workspace id. The unique identifier of the new resource instance. |
+| <a name="output_powervs_workspace_management_subnet_id"></a> [powervs\_workspace\_management\_subnet\_id](#output\_powervs\_workspace\_management\_subnet\_id) | PowerVS infrastructure workspace management subnet id. The unique identifier of the network. |
+| <a name="output_powervs_workspace_resource_id"></a> [powervs\_workspace\_resource\_id](#output\_powervs\_workspace\_resource\_id) | PowerVS infrastructure workspace resource id. The unique ID of the offering. This value is provided by and stored in the global catalog. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/submodules/powervs_workspace/main.tf
+++ b/submodules/powervs_workspace/main.tf
@@ -1,5 +1,5 @@
 #####################################################
-# IBM Cloud PowerVS Resource Configuration
+# IBM Cloud PowerVS Workspace Configuration
 #####################################################
 
 locals {
@@ -37,7 +37,7 @@ resource "ibm_pi_key" "ssh_key" {
 }
 
 #####################################################
-# Create Public and Private Subnets
+# Create Private Subnets
 #####################################################
 
 resource "ibm_pi_network" "management_network" {
@@ -83,6 +83,12 @@ locals {
 
 }
 
+
+#######################################################
+# Using 3 resource blocks for import images as parallel
+# import of multiple images causes an error
+#######################################################
+
 resource "ibm_pi_image" "import_images_1" {
 
   for_each             = toset(local.split_images_1)
@@ -117,5 +123,4 @@ resource "ibm_pi_image" "import_images_3" {
   timeouts {
     create = "9m"
   }
-
 }

--- a/submodules/powervs_workspace/outputs.tf
+++ b/submodules/powervs_workspace/outputs.tf
@@ -1,5 +1,29 @@
 output "powervs_workspace_crn" {
-  depends_on  = [ibm_resource_instance.powervs_workspace]
-  description = "PowerVS infrastructure workspace CRN."
+  description = "PowerVS infrastructure workspace CRN. The full deployment CRN as defined in the global catalog. The Cloud Resource Name (CRN) of the deployment location where the instance is provisioned."
   value       = ibm_resource_instance.powervs_workspace.target_crn
+}
+
+output "powervs_workspace_resource_id" {
+  description = "PowerVS infrastructure workspace resource id. The unique ID of the offering. This value is provided by and stored in the global catalog."
+  value       = ibm_resource_instance.powervs_workspace.resource_id
+}
+
+output "powervs_workspace_guid" {
+  description = "PowerVS infrastructure workspace guid. The GUID of the resource instance."
+  value       = ibm_resource_instance.powervs_workspace.guid
+}
+
+output "powervs_workspace_id" {
+  description = "PowerVS infrastructure workspace id. The unique identifier of the new resource instance."
+  value       = ibm_resource_instance.powervs_workspace.id
+}
+
+output "powervs_workspace_management_subnet_id" {
+  description = "PowerVS infrastructure workspace management subnet id. The unique identifier of the network."
+  value       = ibm_pi_network.management_network.network_id
+}
+
+output "powervs_workspace_backup_subnet_id" {
+  description = "PowerVS infrastructure workspace backup subnet id. The unique identifier of the network."
+  value       = ibm_pi_network.backup_network.network_id
 }

--- a/submodules/terraform_initial_validation/README.md
+++ b/submodules/terraform_initial_validation/README.md
@@ -35,7 +35,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cloud_connection_validate"></a> [cloud\_connection\_validate](#input\_cloud\_connection\_validate) | Verify reuse\_cloud\_connection and transit\_gateway\_name variables | <pre>object({<br>    reuse_cloud_connections = bool<br>    transit_gateway_name    = string<br>  })</pre> | n/a | yes |
+| <a name="input_cloud_connection_validate"></a> [cloud\_connection\_validate](#input\_cloud\_connection\_validate) | Verify reuse\_cloud\_connection and transit\_gateway\_id variables | <pre>object({<br>    reuse_cloud_connections = bool<br>    transit_gateway_id      = string<br>  })</pre> | n/a | yes |
 
 ### Outputs
 

--- a/submodules/terraform_initial_validation/variables.tf
+++ b/submodules/terraform_initial_validation/variables.tf
@@ -1,12 +1,12 @@
 variable "cloud_connection_validate" {
-  description = "Verify reuse_cloud_connection and transit_gateway_name variables"
+  description = "Verify reuse_cloud_connection and transit_gateway_id variables"
   type = object({
     reuse_cloud_connections = bool
-    transit_gateway_name    = string
+    transit_gateway_id      = string
   })
 
   validation {
-    condition     = (!var.cloud_connection_validate.reuse_cloud_connections && var.cloud_connection_validate.transit_gateway_name != null && var.cloud_connection_validate.transit_gateway_name != "") || var.cloud_connection_validate.reuse_cloud_connections
-    error_message = "If reusing cloud connections, Transit gateway name must be provided."
+    condition     = (!var.cloud_connection_validate.reuse_cloud_connections && var.cloud_connection_validate.transit_gateway_id != null && var.cloud_connection_validate.transit_gateway_id != "") || var.cloud_connection_validate.reuse_cloud_connections
+    error_message = "If reusing cloud connections, Transit gateway id must be provided."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,8 +59,8 @@ variable "powervs_backup_network" {
   }
 }
 
-variable "transit_gateway_name" {
-  description = "Name of the existing transit gateway. Required when you create new IBM Cloud connections. Set it to null if reusing cloud connections"
+variable "transit_gateway_id" {
+  description = "ID of the existing transit gateway. Required when you create new IBM Cloud connections. Set it to null if reusing cloud connections"
   type        = string
 }
 

--- a/version.tf
+++ b/version.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, <=1.5.5"
+  required_version = ">= 1.3, <1.6"
   required_providers {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {

--- a/version.tf
+++ b/version.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3, <1.6"
+  required_version = ">= 1.3"
   required_providers {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {

--- a/version.tf
+++ b/version.tf
@@ -3,7 +3,7 @@
 #####################################################
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.3, <=1.5.5"
   required_providers {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {


### PR DESCRIPTION
### Description

* Remove depends_on
* Use transit gateway id in submodule.
* Use Global routing true

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
