### PR TITLE
fix: upgrade ibm provider version to 1.61.0 which has fix for scheamt…

### DIFF
--- a/modules/powervs-vpc-landing-zone/README.md
+++ b/modules/powervs-vpc-landing-zone/README.md
@@ -85,7 +85,7 @@ Creates VPC Landing Zone | Performs VPC VSI OS Config | Creates PowerVS Infrastr
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.58.1 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.61.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
 ### Modules
@@ -95,7 +95,7 @@ Creates VPC Landing Zone | Performs VPC VSI OS Config | Creates PowerVS Infrastr
 | <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 5.7.1 |
 | <a name="module_landing_zone_configure_network_services"></a> [landing\_zone\_configure\_network\_services](#module\_landing\_zone\_configure\_network\_services) | ../ansible-configure-network-services | n/a |
 | <a name="module_landing_zone_configure_proxy_server"></a> [landing\_zone\_configure\_proxy\_server](#module\_landing\_zone\_configure\_proxy\_server) | ../ansible-configure-network-services | n/a |
-| <a name="module_powervs_infra"></a> [powervs\_infra](#module\_powervs\_infra) | terraform-ibm-modules/powervs-workspace/ibm | 1.2.0 |
+| <a name="module_powervs_infra"></a> [powervs\_infra](#module\_powervs\_infra) | terraform-ibm-modules/powervs-workspace/ibm | 1.2.1 |
 
 ### Resources
 

--- a/modules/powervs-vpc-landing-zone/README.md
+++ b/modules/powervs-vpc-landing-zone/README.md
@@ -92,7 +92,7 @@ Creates VPC Landing Zone | Performs VPC VSI OS Config | Creates PowerVS Infrastr
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 4.15.0 |
+| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 5.7.1 |
 | <a name="module_landing_zone_configure_network_services"></a> [landing\_zone\_configure\_network\_services](#module\_landing\_zone\_configure\_network\_services) | ../ansible-configure-network-services | n/a |
 | <a name="module_landing_zone_configure_proxy_server"></a> [landing\_zone\_configure\_proxy\_server](#module\_landing\_zone\_configure\_proxy\_server) | ../ansible-configure-network-services | n/a |
 | <a name="module_powervs_infra"></a> [powervs\_infra](#module\_powervs\_infra) | terraform-ibm-modules/powervs-workspace/ibm | 1.2.0 |

--- a/modules/powervs-vpc-landing-zone/main.tf
+++ b/modules/powervs-vpc-landing-zone/main.tf
@@ -4,7 +4,7 @@
 
 module "landing_zone" {
   source    = "terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module"
-  version   = "5.3.1"
+  version   = "5.7.1"
   providers = { ibm = ibm.ibm-is }
 
   ssh_public_key       = var.ssh_public_key

--- a/modules/powervs-vpc-landing-zone/main.tf
+++ b/modules/powervs-vpc-landing-zone/main.tf
@@ -48,7 +48,7 @@ module "landing_zone_configure_network_services" {
 
 module "powervs_infra" {
   source    = "terraform-ibm-modules/powervs-workspace/ibm"
-  version   = "1.2.0"
+  version   = "1.2.1"
   providers = { ibm = ibm.ibm-pi }
 
   pi_zone                       = var.powervs_zone

--- a/modules/powervs-vpc-landing-zone/presets/1vpc.preset.json.tftpl
+++ b/modules/powervs-vpc-landing-zone/presets/1vpc.preset.json.tftpl
@@ -1,5 +1,4 @@
 {
-    "access_groups": [],
     "appid": {
         "keys": [
             "slz-appid-key"
@@ -82,9 +81,6 @@
             "use_data": false
         }
     ],
-    "iam_account_settings": {
-        "enable": false
-    },
     "key_management": {
         "keys": [
             {

--- a/modules/powervs-vpc-landing-zone/presets/3vpc.preset.json.tftpl
+++ b/modules/powervs-vpc-landing-zone/presets/3vpc.preset.json.tftpl
@@ -1,5 +1,4 @@
 {
-    "access_groups": [],
     "appid": {
         "keys": [
             "slz-appid-key"
@@ -104,9 +103,6 @@
             "use_data": false
         }
     ],
-    "iam_account_settings": {
-        "enable": false
-    },
     "key_management": {
         "keys": [
             {

--- a/modules/powervs-vpc-landing-zone/versions.tf
+++ b/modules/powervs-vpc-landing-zone/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source                = "IBM-Cloud/ibm"
-      version               = ">=1.58.1"
+      version               = ">=1.61.0"
       configuration_aliases = [ibm.ibm-is, ibm.ibm-pi]
     }
     time = {

--- a/reference-architectures/extension/deploy-arch-ibm-pvs-inf-extension.md
+++ b/reference-architectures/extension/deploy-arch-ibm-pvs-inf-extension.md
@@ -11,7 +11,7 @@ authors:
   - name: Arnold Beilmann
   - name: Suraj Bharadwaj
 
-version: v4.0.0
+version: v4.0.1
 
 production: true
 
@@ -47,7 +47,7 @@ content-type: reference-architecture
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="4.0.0"}
+{: toc-version="4.0.1"}
 
 The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with already created Power Virtual Server with VPC landing zone. It builds on existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'.
 

--- a/reference-architectures/full-stack/deploy-arch-ibm-pvs-inf-full-stack.md
+++ b/reference-architectures/full-stack/deploy-arch-ibm-pvs-inf-full-stack.md
@@ -11,7 +11,7 @@ authors:
   - name: Arnold Beilmann
   - name: Suraj Bharadwaj
 
-version: v4.0.0
+version: v4.0.1
 
 # Whether the reference architecture is published to Cloud Docs production.
 # When set to false, the file is available only in staging. Default is false.
@@ -49,7 +49,7 @@ content-type: reference-architecture
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="4.0.0"}
+{: toc-version="4.0.1"}
 
 PowerVS workspace deployment of the Power Virtual Server with VPC landing zone creates VPC services and a Power Virtual Server workspace and interconnects them.
 

--- a/reference-architectures/quickstart/deploy-arch-ibm-pvs-inf-quickstart.md
+++ b/reference-architectures/quickstart/deploy-arch-ibm-pvs-inf-quickstart.md
@@ -11,7 +11,7 @@ authors:
   - name: Arnold Beilmann
   - name: Stafania Saju
 
-version: v4.0.0
+version: v4.0.1
 
 # Whether the reference architecture is published to Cloud Docs production.
 # When set to false, the file is available only in staging. Default is false.
@@ -46,7 +46,7 @@ content-type: reference-architecture
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance=""}
-{: toc-version="4.0.0"}
+{: toc-version="4.0.1"}
 
 Quickstart deployment of the Power Virtual Server with VPC landing zone creates VPC services , a Power Virtual Server workspace and interconnects them. It also deploys a Power Virtual Server of chosen T-shirt size or custom configuration. Supported Os are Aix, IBM i and Linux images.
 

--- a/solutions/extension/README.md
+++ b/solutions/extension/README.md
@@ -39,7 +39,7 @@ If you do not have a PowerVS infrastructure that is the [full stack solution](ht
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.60.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.61.0 |
 
 ### Modules
 

--- a/solutions/extension/versions.tf
+++ b/solutions/extension/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.60.0"
+      version = "=1.61.0"
     }
   }
 }

--- a/solutions/full-stack/README.md
+++ b/solutions/full-stack/README.md
@@ -36,7 +36,7 @@ This example sets up the following infrastructure:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.60.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.61.0 |
 
 ### Modules
 

--- a/solutions/full-stack/versions.tf
+++ b/solutions/full-stack/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.60.0"
+      version = "=1.61.0"
     }
   }
 }

--- a/solutions/import-workspace/README.md
+++ b/solutions/import-workspace/README.md
@@ -16,7 +16,7 @@ This solution takes pre-existing VPC and PowerVS infrastructure resource details
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.60.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.61.0 |
 
 ### Modules
 

--- a/solutions/import-workspace/versions.tf
+++ b/solutions/import-workspace/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.60.0"
+      version = "=1.61.0"
     }
   }
 }

--- a/solutions/quickstart/README.md
+++ b/solutions/quickstart/README.md
@@ -36,7 +36,7 @@ This example sets up the following infrastructure:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3, < 1.6 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.60.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | =1.61.0 |
 
 ### Modules
 

--- a/solutions/quickstart/versions.tf
+++ b/solutions/quickstart/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "=1.60.0"
+      version = "=1.61.0"
     }
   }
 }


### PR DESCRIPTION
### Description

Upgrade TF version to 1.61.0 which has fix for this [data ibm_schematics_workspace bug ](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4990)
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
