### PR TITLE
fix: avoid nfs mount error on network services by waiting for alb to finish its process

### DIFF
--- a/modules/powervs-vpc-landing-zone/main.tf
+++ b/modules/powervs-vpc-landing-zone/main.tf
@@ -85,7 +85,8 @@ locals {
 }
 
 module "configure_network_services" {
-  source = "./submodules/ansible"
+  source     = "./submodules/ansible"
+  depends_on = [module.vpc_file_share_alb]
 
   bastion_host_ip    = local.access_host_or_ip
   ansible_host_or_ip = local.network_services_vsi_ip

--- a/modules/powervs-vpc-landing-zone/submodules/ansible/ansible_node_packages.sh
+++ b/modules/powervs-vpc-landing-zone/submodules/ansible/ansible_node_packages.sh
@@ -4,7 +4,7 @@
 # This bash script performs                                #
 # - installation of packages                               #
 # - ansible galaxy collections.                            #
-# - updates the OS                                         #
+#                                                          #
 ############################################################
 
 GLOBAL_RHEL_PACKAGES="rhel-system-roles rhel-system-roles-sap expect"
@@ -89,12 +89,6 @@ main::install_packages() {
         fi
       done
     done
-
-    # Update OS
-    main::log_info 'Updating OS'
-    if ! yum update -y; then
-      main::log_warning 'OS Update failed'
-    fi
 
     main::log_info "All packages installed successfully"
   fi

--- a/modules/powervs-vpc-landing-zone/submodules/ansible/main.tf
+++ b/modules/powervs-vpc-landing-zone/submodules/ansible/main.tf
@@ -95,7 +95,13 @@ resource "terraform_data" "execute_playbooks" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x ${local.dst_script_file_path}",
-      local.dst_script_file_path,
+      local.dst_script_file_path
+    ]
+  }
+
+  # Reboot OS
+  provisioner "remote-exec" {
+    inline = [
       "shutdown -r +1"
     ]
   }

--- a/modules/powervs-vpc-landing-zone/submodules/ansible/main.tf
+++ b/modules/powervs-vpc-landing-zone/submodules/ansible/main.tf
@@ -98,11 +98,4 @@ resource "terraform_data" "execute_playbooks" {
       local.dst_script_file_path
     ]
   }
-
-  # Reboot OS
-  provisioner "remote-exec" {
-    inline = [
-      "shutdown -r +1"
-    ]
-  }
 }

--- a/reference-architectures/extension/deploy-arch-ibm-pvs-inf-extension.md
+++ b/reference-architectures/extension/deploy-arch-ibm-pvs-inf-extension.md
@@ -15,7 +15,7 @@ use-case: ITServiceManagement
 industry: Technology
 compliance: SAPCertified
 content-type: reference-architecture
-version: v5.0.0
+version: v5.0.1
 
 ---
 
@@ -27,7 +27,7 @@ version: v5.0.0
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="5.0.0"}
+{: toc-version="5.0.1"}
 
 The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with the already created Power Virtual Server with VPC landing zone. It builds on the existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'.
 

--- a/reference-architectures/full-stack/deploy-arch-ibm-pvs-inf-full-stack.md
+++ b/reference-architectures/full-stack/deploy-arch-ibm-pvs-inf-full-stack.md
@@ -15,7 +15,7 @@ use-case: ITServiceManagement
 industry: Technology
 compliance: SAPCertified
 content-type: reference-architecture
-version: v5.0.0
+version: v5.0.1
 
 ---
 
@@ -27,7 +27,7 @@ version: v5.0.0
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="5.0.0"}
+{: toc-version="5.0.1"}
 
 The PowerVS workspace deployment of the Power Virtual Server with VPC landing zone creates VPC services and a Power Virtual Server workspace and interconnects them.
 

--- a/reference-architectures/import-workspace/deploy-arch-ibm-pvs-inf-import-workspace.md
+++ b/reference-architectures/import-workspace/deploy-arch-ibm-pvs-inf-import-workspace.md
@@ -15,7 +15,7 @@ use-case: ITServiceManagement
 industry: Technology
 compliance:
 content-type: reference-architecture
-version: v5.0.0
+version: v5.0.1
 
 ---
 

--- a/reference-architectures/quickstart/deploy-arch-ibm-pvs-inf-quickstart.md
+++ b/reference-architectures/quickstart/deploy-arch-ibm-pvs-inf-quickstart.md
@@ -16,7 +16,7 @@ use-case: ITServiceManagement
 industry: Technology
 compliance:
 content-type: reference-architecture
-version: v5.0.0
+version: v5.0.1
 
 ---
 
@@ -28,7 +28,7 @@ version: v5.0.0
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance=""}
-{: toc-version="5.0.0"}
+{: toc-version="5.0.1"}
 
 Quickstart deployment of the Power Virtual Server with VPC landing zone creates VPC services, a Power Virtual Server workspace, and interconnects them. It also deploys a Power Virtual Server of chosen T-shirt size or custom configuration. Supported Os are Aix, IBM i, and Linux images.
 


### PR DESCRIPTION
### Description

* avoid nfs mount error on network services by waiting for alb to finish its process
* Remove reboot

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
