### PR TITLE
fix: create is_share in correct resource group and update ansible role version

### DIFF
--- a/modules/powervs-vpc-landing-zone/submodules/ansible/ansible_node_packages.sh
+++ b/modules/powervs-vpc-landing-zone/submodules/ansible/ansible_node_packages.sh
@@ -8,7 +8,7 @@
 ############################################################
 
 GLOBAL_RHEL_PACKAGES="rhel-system-roles rhel-system-roles-sap expect"
-GLOBAL_GALAXY_COLLLECTIONS="ibm.power_linux_sap:2.1.1 ansible.utils:3.1.0 ansible.posix:1.5.4 community.general:8.4.0"
+GLOBAL_GALAXY_COLLLECTIONS="ibm.power_linux_sap:2.2.1 ansible.utils:3.1.0 ansible.posix:1.5.4 community.general:8.4.0"
 
 ############################################################
 # Start functions

--- a/modules/powervs-vpc-landing-zone/submodules/fileshare-alb/main.tf
+++ b/modules/powervs-vpc-landing-zone/submodules/fileshare-alb/main.tf
@@ -10,6 +10,7 @@ resource "ibm_is_share" "file_share_nfs" {
   access_control_mode = "security_group"
   iops                = var.file_share_iops
   zone                = var.vpc_zone
+  resource_group      = var.resource_group_id
 }
 
 resource "ibm_is_share_mount_target" "mount_target_nfs" {

--- a/reference-architectures/import/deploy-arch-ibm-pvs-inf-import.md
+++ b/reference-architectures/import/deploy-arch-ibm-pvs-inf-import.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024
-lastupdated: "2024-07-02"
+lastupdated: "2024-07-24"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -15,7 +15,7 @@ use-case: ITServiceManagement
 industry: Technology
 compliance:
 content-type: reference-architecture
-version: v5.3.0
+version: v6.0.0
 
 ---
 
@@ -26,7 +26,7 @@ version: v5.3.0
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="5.3.0"}
+{: toc-version="6.0.0"}
 
 This solution helps to install the deployable architecture ['Power Virtual Server for SAP HANA'](https://cloud.ibm.com/catalog/architecture/deploy-arch-ibm-pvs-sap-9aa6135e-75d5-467e-9f4a-ac2a21c069b8-global) on top of a pre-existing Power Virtual Server(PowerVS) landscape. 'Power Virtual Server for SAP HANA' automation requires a schematics workspace id for installation. The 'Import' solution creates a schematics workspace by taking pre-existing VPC and PowerVS infrastructure resource details as inputs. The ID of this schematics workspace will be the pre-requisite workspace id required by 'Power Virtual Server for SAP HANA' to create and configure the PowerVS instances for SAP on top of the existing infrastructure.
 

--- a/reference-architectures/import/deploy-arch-ibm-pvs-inf-import.md
+++ b/reference-architectures/import/deploy-arch-ibm-pvs-inf-import.md
@@ -15,7 +15,7 @@ use-case: ITServiceManagement
 industry: Technology
 compliance:
 content-type: reference-architecture
-version: v5.2.1
+version: v5.3.0
 
 ---
 
@@ -26,7 +26,7 @@ version: v5.2.1
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="5.2.1"}
+{: toc-version="5.3.0"}
 
 This solution helps to install the deployable architecture ['Power Virtual Server for SAP HANA'](https://cloud.ibm.com/catalog/architecture/deploy-arch-ibm-pvs-sap-9aa6135e-75d5-467e-9f4a-ac2a21c069b8-global) on top of a pre-existing Power Virtual Server(PowerVS) landscape. 'Power Virtual Server for SAP HANA' automation requires a schematics workspace id for installation. The 'Import' solution creates a schematics workspace by taking pre-existing VPC and PowerVS infrastructure resource details as inputs. The ID of this schematics workspace will be the pre-requisite workspace id required by 'Power Virtual Server for SAP HANA' to create and configure the PowerVS instances for SAP on top of the existing infrastructure.
 

--- a/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.md
+++ b/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024
-lastupdated: "2024-07-02"
+lastupdated: "2024-07-24"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -14,7 +14,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v5.3.0
+version: v6.0.0
 compliance: SAPCertified
 
 ---
@@ -27,7 +27,7 @@ compliance: SAPCertified
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="5.3.0"}
+{: toc-version="6.0.0"}
 
 The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with the already created Power Virtual Server with VPC landing zone. It builds on the existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'.
 

--- a/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.md
+++ b/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.md
@@ -14,7 +14,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v5.2.1
+version: v5.3.0
 compliance: SAPCertified
 
 ---
@@ -27,7 +27,7 @@ compliance: SAPCertified
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="5.2.1"}
+{: toc-version="5.3.0"}
 
 The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with the already created Power Virtual Server with VPC landing zone. It builds on the existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'.
 

--- a/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.md
+++ b/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024
-lastupdated: "2024-07-02"
+lastupdated: "2024-07-24"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -15,7 +15,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v5.3.0
+version: v6.0.0
 compliance:
 
 ---
@@ -28,7 +28,7 @@ compliance:
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance=""}
-{: toc-version="5.3.0"}
+{: toc-version="6.0.0"}
 
 Quickstart deployment of the Power Virtual Server with VPC landing zone creates VPC services, a Power Virtual Server workspace, and interconnects them. It also deploys a Power Virtual Server of chosen T-shirt size or custom configuration. Supported Os are Aix, IBM i, and Linux images.
 

--- a/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.md
+++ b/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.md
@@ -15,7 +15,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v5.2.1
+version: v5.3.0
 compliance:
 
 ---
@@ -28,7 +28,7 @@ compliance:
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance=""}
-{: toc-version="5.2.1"}
+{: toc-version="5.3.0"}
 
 Quickstart deployment of the Power Virtual Server with VPC landing zone creates VPC services, a Power Virtual Server workspace, and interconnects them. It also deploys a Power Virtual Server of chosen T-shirt size or custom configuration. Supported Os are Aix, IBM i, and Linux images.
 

--- a/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.md
+++ b/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.md
@@ -14,7 +14,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v5.2.1
+version: v5.3.0
 compliance: SAPCertified
 
 ---
@@ -27,7 +27,7 @@ compliance: SAPCertified
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="5.2.1"}
+{: toc-version="5.3.0"}
 
 The Standard deployment of the Power Virtual Server with VPC landing zone creates VPC services and a Power Virtual Server workspace and interconnects them.
 

--- a/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.md
+++ b/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024
-lastupdated: "2024-07-02"
+lastupdated: "2024-07-24"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -14,7 +14,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v5.3.0
+version: v6.0.0
 compliance: SAPCertified
 
 ---
@@ -27,7 +27,7 @@ compliance: SAPCertified
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="5.3.0"}
+{: toc-version="6.0.0"}
 
 The Standard deployment of the Power Virtual Server with VPC landing zone creates VPC services and a Power Virtual Server workspace and interconnects them.
 


### PR DESCRIPTION
### Description

- create is_share in correct resource group
- update version of power_linux_sap Ansible role

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
