### PR TITLE
chore: remove trailing commas for better UI compatibility

### DIFF
--- a/modules/powervs-vpc-landing-zone/variables.tf
+++ b/modules/powervs-vpc-landing-zone/variables.tf
@@ -213,7 +213,7 @@ variable "powervs_custom_image_cos_configuration" {
   default = {
     "bucket_name" : "",
     "bucket_access" : "",
-    "bucket_region" : "",
+    "bucket_region" : ""
   }
 }
 

--- a/solutions/standard-extend/variables.tf
+++ b/solutions/standard-extend/variables.tf
@@ -115,7 +115,7 @@ variable "powervs_custom_image_cos_configuration" {
   default = {
     "bucket_name" : "",
     "bucket_access" : "",
-    "bucket_region" : "",
+    "bucket_region" : ""
   }
 }
 

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -187,19 +187,19 @@ variable "powervs_custom_images" {
       "image_name" : "",
       "file_name" : "",
       "storage_tier" : "",
-      "sap_type" : null,
+      "sap_type" : null
     },
     "powervs_custom_image2" : {
       "image_name" : "",
       "file_name" : "",
       "storage_tier" : "",
-      "sap_type" : null,
+      "sap_type" : null
     },
     "powervs_custom_image3" : {
       "image_name" : "",
       "file_name" : "",
       "storage_tier" : "",
-      "sap_type" : null,
+      "sap_type" : null
     }
   }
 }
@@ -214,7 +214,7 @@ variable "powervs_custom_image_cos_configuration" {
   default = {
     "bucket_name" : "",
     "bucket_access" : "",
-    "bucket_region" : "",
+    "bucket_region" : ""
   }
 }
 


### PR DESCRIPTION
### Description

Currently, the UI doesn't pick up correctly on the default values of objects if they have a trailing comma. Removed trailing commas in default values to fix that.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
