### PR TITLE
fix: pi instance name was not using prefix

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -538,7 +538,7 @@
               {
                 "diagram": {
                   "caption": "Power Virtual Server with VPC landing zone 'Standard' variation",
-                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.1.4/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.svg",
+                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.1.5/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.svg",
                   "type": "image/svg+xml"
                 },
                 "description": "The Power Virtual Server with VPC landing zone as variation 'Create a new architecture' deploys VPC services and a Power Virtual Server workspace and interconnects them.\n \nRequired and optional management components are configured."
@@ -1174,7 +1174,7 @@
               {
                 "diagram": {
                   "caption": "Power Virtual Server with VPC landing zone 'Quickstart' variation",
-                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.1.4/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.svg",
+                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.1.5/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.svg",
                   "type": "image/svg+xml"
                 },
                 "description": "The Power Virtual Server with VPC landing zone as 'Quickstart' variation of 'Create a new architecture' option deploys VPC services and a Power Virtual Server workspace and interconnects them. It also creates one Power virtual server instance of chosen t-shirt size or custom configuration.\n \nRequired and optional management components are configured."
@@ -1500,7 +1500,7 @@
               {
                 "diagram": {
                   "caption": "Power Virtual Server with VPC landing zone 'Import' variation",
-                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.1.4/reference-architectures/import/deploy-arch-ibm-pvs-inf-import.svg",
+                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.1.5/reference-architectures/import/deploy-arch-ibm-pvs-inf-import.svg",
                   "type": "image/svg+xml"
                 },
                 "description": "This solution helps to install the deployable architecture 'Power Virtual Server for SAP HANA' on top of a pre-existing Power Virtual Server(PowerVS) landscape. 'Power Virtual Server for SAP HANA' automation requires a schematics workspace id for installation. The 'Import' solution creates a schematics workspace by taking pre-existing VPC and PowerVS infrastructure resource details as inputs. The ID of this schematics workspace will be the pre-requisite workspace id required by 'Power Virtual Server for SAP HANA' to create and configure the PowerVS instances for SAP on top of the existing infrastructure.\n \nRequired and optional management components are configured."
@@ -1818,7 +1818,7 @@
               {
                 "diagram": {
                   "caption": "Power Virtual Server with VPC landing zone 'Standard Extend' variation",
-                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.1.4/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.svg",
+                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.1.5/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.svg",
                   "type": "image/svg+xml"
                 },
                 "description": "The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with already created Power Virtual Server with VPC landing zone. It builds on existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'."

--- a/modules/powervs-vpc-landing-zone/README.md
+++ b/modules/powervs-vpc-landing-zone/README.md
@@ -106,10 +106,10 @@ Creates VPC Landing Zone | Performs VPC VSI OS Config | Creates PowerVS Infrastr
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_client_to_site_vpn"></a> [client\_to\_site\_vpn](#module\_client\_to\_site\_vpn) | terraform-ibm-modules/client-to-site-vpn/ibm | 2.1.3 |
+| <a name="module_client_to_site_vpn"></a> [client\_to\_site\_vpn](#module\_client\_to\_site\_vpn) | terraform-ibm-modules/client-to-site-vpn/ibm | 2.1.4 |
 | <a name="module_configure_monitoring_host"></a> [configure\_monitoring\_host](#module\_configure\_monitoring\_host) | ./submodules/ansible | n/a |
 | <a name="module_configure_network_services"></a> [configure\_network\_services](#module\_configure\_network\_services) | ./submodules/ansible | n/a |
-| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 7.2.2 |
+| <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 7.3.0 |
 | <a name="module_powervs_workspace"></a> [powervs\_workspace](#module\_powervs\_workspace) | terraform-ibm-modules/powervs-workspace/ibm | 2.5.0 |
 | <a name="module_private_secret_engine"></a> [private\_secret\_engine](#module\_private\_secret\_engine) | terraform-ibm-modules/secrets-manager-private-cert-engine/ibm | 1.3.5 |
 | <a name="module_secrets_manager_group"></a> [secrets\_manager\_group](#module\_secrets\_manager\_group) | terraform-ibm-modules/secrets-manager-secret-group/ibm | 1.2.2 |

--- a/modules/powervs-vpc-landing-zone/client2sitevpn.tf
+++ b/modules/powervs-vpc-landing-zone/client2sitevpn.tf
@@ -122,7 +122,7 @@ module "secrets_manager_private_certificate" {
 # Create client to site VPN Server
 module "client_to_site_vpn" {
   source    = "terraform-ibm-modules/client-to-site-vpn/ibm"
-  version   = "2.1.3"
+  version   = "2.1.4"
   providers = { ibm = ibm.ibm-is }
   count     = var.client_to_site_vpn.enable ? 1 : 0
 

--- a/modules/powervs-vpc-landing-zone/main.tf
+++ b/modules/powervs-vpc-landing-zone/main.tf
@@ -4,7 +4,7 @@
 
 module "landing_zone" {
   source    = "terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module"
-  version   = "7.2.2"
+  version   = "7.3.0"
   providers = { ibm = ibm.ibm-is }
 
   ssh_public_key       = var.ssh_public_key

--- a/reference-architectures/import/deploy-arch-ibm-pvs-inf-import.md
+++ b/reference-architectures/import/deploy-arch-ibm-pvs-inf-import.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024, 2025
-lastupdated: "2025-02-18"
+lastupdated: "2025-03-14"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -15,7 +15,7 @@ use-case: ITServiceManagement
 industry: Technology
 compliance:
 content-type: reference-architecture
-version: v8.1.4
+version: v8.1.5
 
 ---
 
@@ -26,7 +26,7 @@ version: v8.1.4
 {: toc-content-type="reference-architecture"}
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
-{: toc-version="v8.1.4"}
+{: toc-version="v8.1.5"}
 
 This solution helps to install the deployable architecture ['Power Virtual Server for SAP HANA'](https://cloud.ibm.com/catalog/architecture/deploy-arch-ibm-pvs-sap-9aa6135e-75d5-467e-9f4a-ac2a21c069b8-global) on top of a pre-existing Power Virtual Server(PowerVS) landscape. 'Power Virtual Server for SAP HANA' automation requires a schematics workspace id for installation. The 'Import' solution creates a schematics workspace by taking pre-existing VPC and PowerVS infrastructure resource details as inputs. The ID of this schematics workspace will be the pre-requisite workspace id required by 'Power Virtual Server for SAP HANA' to create and configure the PowerVS instances for SAP on top of the existing infrastructure.
 

--- a/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.md
+++ b/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024, 2025
-lastupdated: "2025-02-18"
+lastupdated: "2025-03-14"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -15,7 +15,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v8.1.4
+version: v8.1.5
 compliance: SAPCertified
 
 ---
@@ -28,7 +28,7 @@ compliance: SAPCertified
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="v8.1.4"}
+{: toc-version="v8.1.5"}
 
 The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with the already created Power Virtual Server with VPC landing zone. It builds on the existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'.
 

--- a/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.md
+++ b/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024, 2025
-lastupdated: "2025-02-18"
+lastupdated: "2025-03-14"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -15,7 +15,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v8.1.4
+version: v8.1.5
 compliance:
 
 ---
@@ -27,7 +27,7 @@ compliance:
 {: toc-content-type="reference-architecture"}
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
-{: toc-version="v8.1.4"}
+{: toc-version="v8.1.5"}
 
 Quickstart deployment of the Power Virtual Server with VPC landing zone creates VPC services, a Power Virtual Server workspace, and interconnects them. It also deploys a Power Virtual Server of chosen T-shirt size or custom configuration. Supported Os are Aix, IBM i, and Linux images.
 

--- a/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.md
+++ b/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024, 2025
-lastupdated: "2025-02-18"
+lastupdated: "2025-03-14"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -15,7 +15,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v8.1.4
+version: v8.1.5
 compliance: SAPCertified
 
 ---
@@ -28,7 +28,7 @@ compliance: SAPCertified
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="v8.1.4"}
+{: toc-version="v8.1.5"}
 
 The Standard deployment of the Power Virtual Server with VPC landing zone creates VPC services and a Power Virtual Server workspace and interconnects them.
 

--- a/solutions/import/README.md
+++ b/solutions/import/README.md
@@ -43,7 +43,7 @@ The pre-existing infrastructure must meet the following conditions to use the 'I
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.75.2 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.76.1 |
 
 ### Modules
 
@@ -58,9 +58,9 @@ The pre-existing infrastructure must meet the following conditions to use the 'I
 
 | Name | Type |
 |------|------|
-| [ibm_is_network_acl.management_acls_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.75.2/docs/data-sources/is_network_acl) | data source |
-| [ibm_is_subnet.management_subnets_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.75.2/docs/data-sources/is_subnet) | data source |
-| [ibm_tg_gateway.tgw_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.75.2/docs/data-sources/tg_gateway) | data source |
+| [ibm_is_network_acl.management_acls_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.76.1/docs/data-sources/is_network_acl) | data source |
+| [ibm_is_subnet.management_subnets_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.76.1/docs/data-sources/is_subnet) | data source |
+| [ibm_tg_gateway.tgw_ds](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.76.1/docs/data-sources/tg_gateway) | data source |
 
 ### Inputs
 

--- a/solutions/import/versions.tf
+++ b/solutions/import/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.75.2"
+      version = "1.76.1"
     }
   }
 }

--- a/solutions/standard-extend/README.md
+++ b/solutions/standard-extend/README.md
@@ -38,7 +38,7 @@ If you do not have a PowerVS infrastructure that is the [Standard variation](htt
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.75.2 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.76.1 |
 
 ### Modules
 
@@ -50,8 +50,8 @@ If you do not have a PowerVS infrastructure that is the [Standard variation](htt
 
 | Name | Type |
 |------|------|
-| [ibm_schematics_output.schematics_output](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.75.2/docs/data-sources/schematics_output) | data source |
-| [ibm_schematics_workspace.schematics_workspace](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.75.2/docs/data-sources/schematics_workspace) | data source |
+| [ibm_schematics_output.schematics_output](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.76.1/docs/data-sources/schematics_output) | data source |
+| [ibm_schematics_workspace.schematics_workspace](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.76.1/docs/data-sources/schematics_workspace) | data source |
 
 ### Inputs
 

--- a/solutions/standard-extend/versions.tf
+++ b/solutions/standard-extend/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.75.2"
+      version = "1.76.1"
     }
   }
 }

--- a/solutions/standard-plus-vsi/README.md
+++ b/solutions/standard-plus-vsi/README.md
@@ -54,7 +54,7 @@ This example sets up the following infrastructure:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_powervs_instance"></a> [powervs\_instance](#module\_powervs\_instance) | terraform-ibm-modules/powervs-instance/ibm | 2.4.1 |
+| <a name="module_powervs_instance"></a> [powervs\_instance](#module\_powervs\_instance) | terraform-ibm-modules/powervs-instance/ibm | 2.4.2 |
 | <a name="module_standard"></a> [standard](#module\_standard) | ../../modules/powervs-vpc-landing-zone | n/a |
 
 ### Resources

--- a/solutions/standard-plus-vsi/README.md
+++ b/solutions/standard-plus-vsi/README.md
@@ -48,7 +48,7 @@ This example sets up the following infrastructure:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.75.2 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.76.1 |
 
 ### Modules
 

--- a/solutions/standard-plus-vsi/catalogValidationValues.json.template
+++ b/solutions/standard-plus-vsi/catalogValidationValues.json.template
@@ -1,6 +1,6 @@
 {
   "ibmcloud_api_key": $VALIDATION_APIKEY,
-  "powervs_zone": "sao04",
+  "powervs_zone": "dal10",
   "prefix": $PREFIX,
   "tshirt_size": {
       "tshirt_size":"aix_xs",

--- a/solutions/standard-plus-vsi/locals.tf
+++ b/solutions/standard-plus-vsi/locals.tf
@@ -44,7 +44,7 @@ locals {
   pi_instance = {
     pi_image_id             = lookup(module.standard.powervs_images, local.qs_tshirt_choice.image, null)
     pi_networks             = [module.standard.powervs_management_subnet, module.standard.powervs_backup_subnet]
-    pi_instance_name        = "pi-qs"
+    pi_instance_name        = "${var.prefix}-pi-qs"
     pi_sap_profile_id       = local.sap_system_creation_enabled ? local.qs_tshirt_choice.sap_profile_id : null
     pi_server_type          = local.sap_system_creation_enabled ? null : local.qs_tshirt_choice.server_type
     pi_number_of_processors = local.sap_system_creation_enabled ? null : local.qs_tshirt_choice.cores

--- a/solutions/standard-plus-vsi/main.tf
+++ b/solutions/standard-plus-vsi/main.tf
@@ -40,7 +40,7 @@ module "standard" {
 
 module "powervs_instance" {
   source    = "terraform-ibm-modules/powervs-instance/ibm"
-  version   = "2.4.1"
+  version   = "2.4.2"
   providers = { ibm = ibm.ibm-pi }
 
   pi_workspace_guid      = module.standard.powervs_workspace_guid

--- a/solutions/standard-plus-vsi/versions.tf
+++ b/solutions/standard-plus-vsi/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.75.2"
+      version = "1.76.1"
     }
   }
 }

--- a/solutions/standard/README.md
+++ b/solutions/standard/README.md
@@ -47,7 +47,7 @@ This example sets up the following infrastructure:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.75.2 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.76.1 |
 
 ### Modules
 

--- a/solutions/standard/versions.tf
+++ b/solutions/standard/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.75.2"
+      version = "1.76.1"
     }
   }
 }

--- a/tests/common-go-assets/cloudinfo-region-power-prefs.yaml
+++ b/tests/common-go-assets/cloudinfo-region-power-prefs.yaml
@@ -2,6 +2,6 @@
 - name: osa21
   useForTest: true
   testPriority: 1
-- name: sao04
+- name: dal10
   useForTest: true
   testPriority: 2


### PR DESCRIPTION
### Description

Name of the PowerVS instance created in the Quickstart variation was hardcoded. Changed it to use the prefix.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
