### PR TITLE
chore: auto validate the extend standard landscape

### DIFF
--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -21,7 +21,6 @@ offerings:
       - name: standard-extend
         mark_ready: false
         install_type: extension
-        import_only: true
         scc:
           instance_id: d9f6ba0c-dd0e-4348-a834-6002b675fe40
           region: us-south

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -534,7 +534,19 @@
                 "description": "NFS as service, NTP forwarder, and DNS forwarder reachable from PowerVS Workspace"
               },
               {
+                "title": "Client to site VPN with new or existing Secrets Manager instance",
+                "description": "Optional"
+              },
+              {
+                "title": "SCC Workload Protection instance",
+                "description": "Optional"
+              },
+              {
                 "title": "Monitoring Instance and Monitoring Intel VSI Host",
+                "description": "Optional"
+              },
+              {
+                "title": "Bring your own image to PowerVS",
                 "description": "Optional"
               }
             ],
@@ -1177,8 +1189,20 @@
                 "description": "NFS as service, NTP forwarder, and DNS forwarder reachable from PowerVS Workspace"
               },
               {
+                "title": "Client to site VPN with new or existing Secrets Manager instance",
+                "description": "Optional"
+              },
+              {
+                "title": "SCC Workload Protection instance",
+                "description": "Optional"
+              },
+              {
                 "title": "Monitoring Instance and Monitoring Intel VSI Host",
                 "description": "Optional"
+              },
+              {
+                "title": "Bring your own image to PowerVS",
+                "description": "No"
               }
             ],
             "diagrams": [
@@ -1496,6 +1520,10 @@
               {
                 "title": "Power Virtual Server Workspace",
                 "description": "PowerVS Workspace with all required components in different zone. Used for HA scenario."
+              },
+              {
+                "title": "Bring your own image to PowerVS",
+                "description": "Optional"
               }
             ],
             "diagrams": [

--- a/solutions/standard-extend/catalogValidationValues.json.template
+++ b/solutions/standard-extend/catalogValidationValues.json.template
@@ -1,0 +1,6 @@
+{
+  "ibmcloud_api_key": $VALIDATION_APIKEY,
+  "powervs_zone": "eu-de-2",
+  "powervs_resource_group_name": "Default",
+  "prerequisite_workspace_id": "us-east.workspace.globalcatalog-collection.2ad1e7ad"
+}

--- a/solutions/standard-plus-vsi/catalogValidationValues.json.template
+++ b/solutions/standard-plus-vsi/catalogValidationValues.json.template
@@ -6,7 +6,7 @@
       "tshirt_size":"aix_xs",
       "image":"7300-03-00"
    },
-  "powervs_resource_group_name": "Automation",
+  "powervs_resource_group_name": "Default",
   "ssh_public_key": $SSH_PUB_KEY,
   "ssh_private_key": $SSH_PRV_KEY,
   "ansible_vault_password": "SecurePassw0rd!"

--- a/solutions/standard/catalogValidationValues.json.template
+++ b/solutions/standard/catalogValidationValues.json.template
@@ -1,6 +1,6 @@
 {
   "prefix": $PREFIX,
-  "powervs_resource_group_name": "Automation",
+  "powervs_resource_group_name": "Default",
   "powervs_zone": "eu-de-1",
   "external_access_ip": "0.0.0.0/0",
   "ssh_public_key": $SSH_PUB_KEY,


### PR DESCRIPTION
### Description

Created a schematics workspace which is valid, and deleted all resources except the transit gateway which is required by the extend standard landscape to attach the new powervs workspace to TGW. 

This avoids validating the extend standard landscape manually and will be handled by the catalog onboarding pipeline



### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
