### PR TITLE
fix: expose kmy_key and ssh_key_data from landing zone

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -371,6 +371,12 @@
               "key": "vsi_names"
             },
             {
+              "key": "key_map"
+            },
+            {
+              "key": "vsi_ssh_key_data"
+            },
+            {
               "key": "application_load_balancer"
             },
             {
@@ -554,7 +560,7 @@
               {
                 "diagram": {
                   "caption": "Power Virtual Server with VPC landing zone 'Standard Landscape' variation",
-                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.4.0/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.svg",
+                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.4.1/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.svg",
                   "type": "image/svg+xml"
                 },
                 "description": "The Power Virtual Server with VPC landing zone as variation 'Create a new architecture' deploys VPC services and a Power Virtual Server workspace and interconnects them.\n \nRequired and optional management components are configured."
@@ -1035,6 +1041,12 @@
               "key": "vsi_list"
             },
             {
+              "key": "key_map"
+            },
+            {
+              "key": "vsi_ssh_key_data"
+            },
+            {
               "key": "resource_group_data"
             },
             {
@@ -1209,7 +1221,7 @@
               {
                 "diagram": {
                   "caption": "Power Virtual Server with VPC landing zone 'Quickstart' variation",
-                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.4.0/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.svg",
+                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.4.1/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.svg",
                   "type": "image/svg+xml"
                 },
                 "description": "The Power Virtual Server with VPC landing zone as 'Quickstart' variation of 'Create a new architecture' option deploys VPC services and a Power Virtual Server workspace and interconnects them. It also creates one Power virtual server instance of chosen t-shirt size or custom configuration.\n \nRequired and optional management components are configured."
@@ -1426,6 +1438,12 @@
               "key": "vsi_names"
             },
             {
+              "key": "key_map"
+            },
+            {
+              "key": "vsi_ssh_key_data"
+            },
+            {
               "key": "application_load_balancer"
             },
             {
@@ -1530,7 +1548,7 @@
               {
                 "diagram": {
                   "caption": "Power Virtual Server with VPC landing zone 'Extend Standard Landscape' variation",
-                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.4.0/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.svg",
+                  "url": "https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-powervs-infrastructure/refs/tags/v8.4.1/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.svg",
                   "type": "image/svg+xml"
                 },
                 "description": "The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with already created Power Virtual Server with VPC landing zone. It builds on existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'."

--- a/modules/powervs-vpc-landing-zone/README.md
+++ b/modules/powervs-vpc-landing-zone/README.md
@@ -109,7 +109,7 @@ Creates VPC Landing Zone | Performs VPC VSI OS Config | Creates PowerVS Infrastr
 | <a name="module_configure_network_services"></a> [configure\_network\_services](#module\_configure\_network\_services) | ./submodules/ansible | n/a |
 | <a name="module_configure_scc_wp_agent"></a> [configure\_scc\_wp\_agent](#module\_configure\_scc\_wp\_agent) | ./submodules/ansible | n/a |
 | <a name="module_landing_zone"></a> [landing\_zone](#module\_landing\_zone) | terraform-ibm-modules/landing-zone/ibm//patterns//vsi//module | 7.4.4 |
-| <a name="module_powervs_workspace"></a> [powervs\_workspace](#module\_powervs\_workspace) | terraform-ibm-modules/powervs-workspace/ibm | 3.0.1 |
+| <a name="module_powervs_workspace"></a> [powervs\_workspace](#module\_powervs\_workspace) | terraform-ibm-modules/powervs-workspace/ibm | 3.0.2 |
 | <a name="module_private_secret_engine"></a> [private\_secret\_engine](#module\_private\_secret\_engine) | terraform-ibm-modules/secrets-manager-private-cert-engine/ibm | 1.3.6 |
 | <a name="module_scc_wp_instance"></a> [scc\_wp\_instance](#module\_scc\_wp\_instance) | terraform-ibm-modules/scc-workload-protection/ibm | 1.5.10 |
 | <a name="module_secrets_manager_group"></a> [secrets\_manager\_group](#module\_secrets\_manager\_group) | terraform-ibm-modules/secrets-manager-secret-group/ibm | 1.3.4 |
@@ -167,6 +167,7 @@ Creates VPC Landing Zone | Performs VPC VSI OS Config | Creates PowerVS Infrastr
 | <a name="output_ansible_host_or_ip"></a> [ansible\_host\_or\_ip](#output\_ansible\_host\_or\_ip) | Central Ansible node private IP address. |
 | <a name="output_application_load_balancer"></a> [application\_load\_balancer](#output\_application\_load\_balancer) | Details of application load balancer. |
 | <a name="output_dns_host_or_ip"></a> [dns\_host\_or\_ip](#output\_dns\_host\_or\_ip) | DNS forwarder host for created PowerVS infrastructure. |
+| <a name="output_key_map"></a> [key\_map](#output\_key\_map) | Map of ids and keys for keys created |
 | <a name="output_monitoring_instance"></a> [monitoring\_instance](#output\_monitoring\_instance) | Details of the IBM Cloud Monitoring Instance: CRN, location, guid, monitoring\_host\_ip. |
 | <a name="output_network_services_config"></a> [network\_services\_config](#output\_network\_services\_config) | Complete configuration of network management services. |
 | <a name="output_nfs_host_or_ip_path"></a> [nfs\_host\_or\_ip\_path](#output\_nfs\_host\_or\_ip\_path) | NFS host for created PowerVS infrastructure. |
@@ -192,4 +193,5 @@ Creates VPC Landing Zone | Performs VPC VSI OS Config | Creates PowerVS Infrastr
 | <a name="output_vpc_names"></a> [vpc\_names](#output\_vpc\_names) | A list of the names of the VPC. |
 | <a name="output_vsi_list"></a> [vsi\_list](#output\_vsi\_list) | A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP. |
 | <a name="output_vsi_names"></a> [vsi\_names](#output\_vsi\_names) | A list of the vsis names provisioned within the VPCs. |
+| <a name="output_vsi_ssh_key_data"></a> [vsi\_ssh\_key\_data](#output\_vsi\_ssh\_key\_data) | List of SSH key data |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/powervs-vpc-landing-zone/main.tf
+++ b/modules/powervs-vpc-landing-zone/main.tf
@@ -134,7 +134,7 @@ locals {
 
 module "powervs_workspace" {
   source  = "terraform-ibm-modules/powervs-workspace/ibm"
-  version = "3.0.1"
+  version = "3.0.2"
 
   providers = { ibm = ibm.ibm-pi }
 

--- a/modules/powervs-vpc-landing-zone/outputs.tf
+++ b/modules/powervs-vpc-landing-zone/outputs.tf
@@ -47,6 +47,16 @@ output "vpc_data" {
   value       = module.landing_zone.vpc_data
 }
 
+output "key_map" {
+  description = "Map of ids and keys for keys created"
+  value       = module.landing_zone.key_map
+}
+
+output "vsi_ssh_key_data" {
+  description = "List of SSH key data"
+  value       = module.landing_zone.ssh_key_data
+}
+
 output "resource_group_data" {
   description = "List of resource groups data used within landing zone."
   value       = module.landing_zone.resource_group_data

--- a/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.md
+++ b/reference-architectures/standard-extend/deploy-arch-ibm-pvs-inf-standard-extend.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024, 2025
-lastupdated: "2025-05-06"
+lastupdated: "2025-05-08"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -15,7 +15,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v8.4.0
+version: v8.4.1
 compliance: SAPCertified
 
 ---
@@ -28,7 +28,7 @@ compliance: SAPCertified
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="v8.4.0"}
+{: toc-version="v8.4.1"}
 
 The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with the already created Power Virtual Server with VPC landing zone. It builds on the existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'.
 

--- a/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.md
+++ b/reference-architectures/standard-plus-vsi/deploy-arch-ibm-pvs-inf-standard-plus-vsi.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024, 2025
-lastupdated: "2025-05-06"
+lastupdated: "2025-05-08"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -16,7 +16,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v8.4.0
+version: v8.4.1
 compliance:
 
 ---
@@ -28,7 +28,7 @@ compliance:
 {: toc-content-type="reference-architecture"}
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
-{: toc-version="v8.4.0"}
+{: toc-version="v8.4.1"}
 
 Quickstart deployment of the Power Virtual Server with VPC landing zone creates VPC services, a Power Virtual Server workspace, and interconnects them. It also deploys a Power Virtual Server of chosen T-shirt size or custom configuration. Supported Os are Aix, IBM i, and Linux images.
 

--- a/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.md
+++ b/reference-architectures/standard/deploy-arch-ibm-pvs-inf-standard.md
@@ -1,7 +1,7 @@
 ---
 copyright:
   years: 2024, 2025
-lastupdated: "2025-05-06"
+lastupdated: "2025-05-08"
 keywords:
 subcollection: deployable-reference-architectures
 authors:
@@ -15,7 +15,7 @@ image_source: https://github.com/terraform-ibm-modules/terraform-ibm-powervs-inf
 use-case: ITServiceManagement
 industry: Technology
 content-type: reference-architecture
-version: v8.4.0
+version: v8.4.1
 compliance: SAPCertified
 
 ---
@@ -28,7 +28,7 @@ compliance: SAPCertified
 {: toc-industry="Technology"}
 {: toc-use-case="ITServiceManagement"}
 {: toc-compliance="SAPCertified"}
-{: toc-version="v8.4.0"}
+{: toc-version="v8.4.1"}
 
 The Standard deployment of the Power Virtual Server with VPC landing zone creates VPC services and a Power Virtual Server workspace and interconnects them.
 

--- a/solutions/standard-extend/README.md
+++ b/solutions/standard-extend/README.md
@@ -42,7 +42,7 @@ If you do not have a PowerVS infrastructure that is the [Standard Landscape Vari
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_powervs_workspace"></a> [powervs\_workspace](#module\_powervs\_workspace) | terraform-ibm-modules/powervs-workspace/ibm | 3.0.1 |
+| <a name="module_powervs_workspace"></a> [powervs\_workspace](#module\_powervs\_workspace) | terraform-ibm-modules/powervs-workspace/ibm | 3.0.2 |
 
 ### Resources
 
@@ -75,6 +75,7 @@ If you do not have a PowerVS infrastructure that is the [Standard Landscape Vari
 | <a name="output_ansible_host_or_ip"></a> [ansible\_host\_or\_ip](#output\_ansible\_host\_or\_ip) | Central Ansible node private IP address. |
 | <a name="output_application_load_balancer"></a> [application\_load\_balancer](#output\_application\_load\_balancer) | Details of application load balancer. |
 | <a name="output_dns_host_or_ip"></a> [dns\_host\_or\_ip](#output\_dns\_host\_or\_ip) | DNS forwarder host for created PowerVS infrastructure. |
+| <a name="output_key_map"></a> [key\_map](#output\_key\_map) | Map of ids and keys for keys created |
 | <a name="output_monitoring_instance"></a> [monitoring\_instance](#output\_monitoring\_instance) | Details of the IBM Cloud Monitoring Instance: CRN, location, guid. |
 | <a name="output_network_services_config"></a> [network\_services\_config](#output\_network\_services\_config) | Complete configuration of network management services. |
 | <a name="output_nfs_host_or_ip_path"></a> [nfs\_host\_or\_ip\_path](#output\_nfs\_host\_or\_ip\_path) | NFS host for created PowerVS infrastructure. |
@@ -99,4 +100,5 @@ If you do not have a PowerVS infrastructure that is the [Standard Landscape Vari
 | <a name="output_vpc_names"></a> [vpc\_names](#output\_vpc\_names) | A list of the names of the VPC. |
 | <a name="output_vsi_list"></a> [vsi\_list](#output\_vsi\_list) | A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP. |
 | <a name="output_vsi_names"></a> [vsi\_names](#output\_vsi\_names) | A list of the vsis names provisioned within the VPCs. |
+| <a name="output_vsi_ssh_key_data"></a> [vsi\_ssh\_key\_data](#output\_vsi\_ssh\_key\_data) | List of VSI SSH key data |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/solutions/standard-extend/main.tf
+++ b/solutions/standard-extend/main.tf
@@ -23,7 +23,7 @@ locals {
 
 module "powervs_workspace" {
   source  = "terraform-ibm-modules/powervs-workspace/ibm"
-  version = "3.0.1"
+  version = "3.0.2"
 
   pi_zone                                 = var.powervs_zone
   pi_resource_group_name                  = var.powervs_resource_group_name

--- a/solutions/standard-extend/outputs.tf
+++ b/solutions/standard-extend/outputs.tf
@@ -22,6 +22,15 @@ output "vpc_data" {
   value       = local.standard_output[0].vpc_data.value
 }
 
+output "key_map" {
+  description = "Map of ids and keys for keys created"
+  value       = local.standard_output[0].key_map.value
+}
+
+output "vsi_ssh_key_data" {
+  description = "List of VSI SSH key data"
+  value       = local.standard_output[0].vsi_ssh_key_data.value
+}
 output "application_load_balancer" {
   description = "Details of application load balancer."
   value       = local.standard_output[0].application_load_balancer.value

--- a/solutions/standard-plus-vsi/README.md
+++ b/solutions/standard-plus-vsi/README.md
@@ -105,6 +105,7 @@ This example sets up the following infrastructure:
 | <a name="output_ansible_host_or_ip"></a> [ansible\_host\_or\_ip](#output\_ansible\_host\_or\_ip) | Central Ansible node private IP address. |
 | <a name="output_application_load_balancer"></a> [application\_load\_balancer](#output\_application\_load\_balancer) | Details of application load balancer. |
 | <a name="output_dns_host_or_ip"></a> [dns\_host\_or\_ip](#output\_dns\_host\_or\_ip) | DNS forwarder host for created PowerVS infrastructure. |
+| <a name="output_key_map"></a> [key\_map](#output\_key\_map) | Map of ids and keys for keys created |
 | <a name="output_monitoring_instance"></a> [monitoring\_instance](#output\_monitoring\_instance) | Details of the IBM Cloud Monitoring Instance: CRN, location, guid. |
 | <a name="output_network_services_config"></a> [network\_services\_config](#output\_network\_services\_config) | Complete configuration of network management services. |
 | <a name="output_nfs_host_or_ip_path"></a> [nfs\_host\_or\_ip\_path](#output\_nfs\_host\_or\_ip\_path) | NFS host for created PowerVS infrastructure. |
@@ -133,4 +134,5 @@ This example sets up the following infrastructure:
 | <a name="output_vpc_names"></a> [vpc\_names](#output\_vpc\_names) | A list of the names of the VPC. |
 | <a name="output_vsi_list"></a> [vsi\_list](#output\_vsi\_list) | A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP. |
 | <a name="output_vsi_names"></a> [vsi\_names](#output\_vsi\_names) | A list of the vsis names provisioned within the VPCs. |
+| <a name="output_vsi_ssh_key_data"></a> [vsi\_ssh\_key\_data](#output\_vsi\_ssh\_key\_data) | List of VSI SSH key data |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/solutions/standard-plus-vsi/outputs.tf
+++ b/solutions/standard-plus-vsi/outputs.tf
@@ -22,6 +22,16 @@ output "vpc_data" {
   value       = module.standard.vpc_data
 }
 
+output "key_map" {
+  description = "Map of ids and keys for keys created"
+  value       = module.standard.key_map
+}
+
+output "vsi_ssh_key_data" {
+  description = "List of VSI SSH key data"
+  value       = module.standard.vsi_ssh_key_data
+}
+
 output "application_load_balancer" {
   description = "Details of application load balancer."
   value       = module.standard.application_load_balancer

--- a/solutions/standard/README.md
+++ b/solutions/standard/README.md
@@ -103,6 +103,7 @@ No resources.
 | <a name="output_ansible_host_or_ip"></a> [ansible\_host\_or\_ip](#output\_ansible\_host\_or\_ip) | Central Ansible node private IP address. |
 | <a name="output_application_load_balancer"></a> [application\_load\_balancer](#output\_application\_load\_balancer) | Details of application load balancer. |
 | <a name="output_dns_host_or_ip"></a> [dns\_host\_or\_ip](#output\_dns\_host\_or\_ip) | DNS forwarder host for created PowerVS infrastructure. |
+| <a name="output_key_map"></a> [key\_map](#output\_key\_map) | Map of ids and keys for keys created |
 | <a name="output_monitoring_instance"></a> [monitoring\_instance](#output\_monitoring\_instance) | Details of the IBM Cloud Monitoring Instance: CRN, location, guid. |
 | <a name="output_network_services_config"></a> [network\_services\_config](#output\_network\_services\_config) | Complete configuration of network management services. |
 | <a name="output_nfs_host_or_ip_path"></a> [nfs\_host\_or\_ip\_path](#output\_nfs\_host\_or\_ip\_path) | NFS host for created PowerVS infrastructure. |
@@ -129,4 +130,5 @@ No resources.
 | <a name="output_vpc_names"></a> [vpc\_names](#output\_vpc\_names) | A list of the names of the VPC. |
 | <a name="output_vsi_list"></a> [vsi\_list](#output\_vsi\_list) | A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP. |
 | <a name="output_vsi_names"></a> [vsi\_names](#output\_vsi\_names) | A list of the vsis names provisioned within the VPCs. |
+| <a name="output_vsi_ssh_key_data"></a> [vsi\_ssh\_key\_data](#output\_vsi\_ssh\_key\_data) | List of VSI SSH key data |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/solutions/standard/outputs.tf
+++ b/solutions/standard/outputs.tf
@@ -22,6 +22,16 @@ output "vpc_data" {
   value       = module.standard.vpc_data
 }
 
+output "key_map" {
+  description = "Map of ids and keys for keys created"
+  value       = module.standard.key_map
+}
+
+output "vsi_ssh_key_data" {
+  description = "List of VSI SSH key data"
+  value       = module.standard.vsi_ssh_key_data
+}
+
 output "application_load_balancer" {
   description = "Details of application load balancer."
   value       = module.standard.application_load_balancer


### PR DESCRIPTION
### Description

 1. expose kmy_key and ssh_key_data from landing zone
 2. Upgrade workspace version to 3.0.2

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
