### PR TITLE
fix(deps): lock the DA into terraform version 1.10.5

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -567,7 +567,8 @@
                 "description": "The Power Virtual Server with VPC landing zone as variation 'Create a new architecture' deploys VPC services and a Power Virtual Server workspace and interconnects them.\n \nRequired and optional management components are configured."
               }
             ]
-          }
+          },
+          "terraform_version": "1.10.5"
         },
         {
           "label": "Quickstart",
@@ -1225,7 +1226,8 @@
                 "description": "The Power Virtual Server with VPC landing zone as 'Quickstart' variation of 'Create a new architecture' option deploys VPC services and a Power Virtual Server workspace and interconnects them. It also creates one Power virtual server instance of chosen t-shirt size or custom configuration.\n \nRequired and optional management components are configured."
               }
             ]
-          }
+          },
+          "terraform_version": "1.10.5"
         },
         {
           "label": "Extend Standard Landscape",
@@ -1552,7 +1554,8 @@
                 "description": "The Power Virtual Server with VPC landing zone as variation 'Extend Power Virtual Server with VPC landing zone' creates an additional Power Virtual Server workspace and connects it with already created Power Virtual Server with VPC landing zone. It builds on existing Power Virtual Server with VPC landing zone deployed as a variation 'Create a new architecture'."
               }
             ]
-          }
+          },
+          "terraform_version": "1.10.5"
         }
       ]
     }


### PR DESCRIPTION

        This PR ensures that the `ibm_catalog.json` file includes the required `terraform_version` field.

        An upcoming version of **`common-dev-assets`** will introduce an updated `pre-commit` hook that enforces this check. Applying this change now ensures compatibility with the new hook and avoids future commit failures.
        